### PR TITLE
fix: form reset (FrontEnd), duplicate answer validation (FrontEnd + BackEnd)

### DIFF
--- a/api/src/services/question_option.py
+++ b/api/src/services/question_option.py
@@ -9,6 +9,12 @@ async def create_question_options(
     options_data: List[QuestionOptionCreate]
 ) -> List[QuestionOptionPublic]:
     """Create multiple question options"""
+    # Check for duplicate option texts within the same question
+    for qid in set(o.question_id for o in options_data):
+        texts = [o.option_text.strip().lower() for o in options_data if o.question_id == qid]
+        if len(texts) != len(set(texts)):
+            raise HTTPException(status_code=400, detail="Duplicate option texts are not allowed")
+    
     options = [QuestionOption.model_validate(x) for x in options_data]
     session.add_all(options)
     await session.commit()

--- a/web/src/components/QuestionModal.tsx
+++ b/web/src/components/QuestionModal.tsx
@@ -36,6 +36,7 @@ export default function QuestionModal({
   const [correctAnswer, setCorrectAnswer] = useState<number | null>(null);
   const [showError, setShowError] = useState(false);
   const [showQuestionError, setShowQuestionError] = useState(false);
+  const [showDuplicateError, setShowDuplicateError] = useState(false);
 
   useEffect(() => {
     if (editingQuestion?.question) {
@@ -49,7 +50,7 @@ export default function QuestionModal({
       }));
       setOptions(optionsArray);
       setCorrectAnswer(q.answer);
-    } else {
+    } else if (isOpen) {
       setQuestionText("");
       setOptions([
         { id: 1, value: "" },
@@ -61,7 +62,8 @@ export default function QuestionModal({
     }
     setShowError(false);
     setShowQuestionError(false);
-  }, [editingQuestion]);
+    setShowDuplicateError(false);
+  }, [editingQuestion, isOpen]);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -73,14 +75,17 @@ export default function QuestionModal({
     
     // Check for empty options
     const emptyOptions = options.filter(opt => !opt.value.trim());
-    // if (emptyOptions.length > 0) {
-    //   alert("Por favor, preencha todas as opções");
-
-    //   return;
-    // }
     
     if (correctAnswer === null || emptyOptions.length > 0) {
       setShowError(true);
+      return;
+    }
+
+    // Check for duplicate options
+    const optionValues = options.map(opt => opt.value.trim().toLowerCase());
+    const hasDuplicates = optionValues.length !== new Set(optionValues).size;
+    if (hasDuplicates) {
+      setShowDuplicateError(true);
       return;
     }
 
@@ -109,6 +114,7 @@ export default function QuestionModal({
     setOptions(options.map(opt => 
       opt.id === id ? { ...opt, value } : opt
     ));
+    setShowDuplicateError(false);
   };
 
   const addOption = () => {
@@ -244,7 +250,14 @@ export default function QuestionModal({
                   </p>
                 </div>
               )}
-              {!showError && (
+              {showDuplicateError && (
+                <div className="p-4 bg-red-50 border border-red-200 rounded-lg mt-3">
+                  <p className="text-sm text-red-700">
+                    Não é permitido ter <span className="font-medium">opções duplicadas</span>.
+                  </p>
+                </div>
+              )}
+              {!showError && !showDuplicateError && (
                 <p className="text-sm text-gray-500 mt-3">
                   Selecione a opção correta clicando no círculo ao lado
                 </p>


### PR DESCRIPTION

This pull request introduces validation to prevent duplicate question options both on the backend and the frontend, and improves user feedback in the question creation modal. The changes ensure that users cannot submit or create questions with duplicate option texts, providing a more robust and user-friendly experience.

**Backend validation:**

* Added a check in `create_question_options` (in `question_option.py`) to raise an HTTP 400 error if duplicate option texts are detected for the same question, ensuring data integrity at the API level.

**Frontend validation and user feedback:**

* Added logic in `QuestionModal.tsx` to detect duplicate option texts before submitting a question, preventing the form submission and displaying an appropriate error message.
* Introduced a new state variable `showDuplicateError` and updated the modal to show a specific error message when duplicate options are present. [[1]](diffhunk://#diff-2b7251fa85eafca6b6ddfa2fcb1e3ce282208ed2eecb9eacdd135713ca14d4f0R39) [[2]](diffhunk://#diff-2b7251fa85eafca6b6ddfa2fcb1e3ce282208ed2eecb9eacdd135713ca14d4f0L247-R260)
* Reset duplicate error state appropriately when editing questions, opening the modal, or changing option values, ensuring error messages are cleared at the right times. [[1]](diffhunk://#diff-2b7251fa85eafca6b6ddfa2fcb1e3ce282208ed2eecb9eacdd135713ca14d4f0L64-R66) [[2]](diffhunk://#diff-2b7251fa85eafca6b6ddfa2fcb1e3ce282208ed2eecb9eacdd135713ca14d4f0R117) [[3]](diffhunk://#diff-2b7251fa85eafca6b6ddfa2fcb1e3ce282208ed2eecb9eacdd135713ca14d4f0L52-R53)
