### PR TITLE
fix: changed from 'Gerar Exames' to simply 'Exames' and connected the…

### DIFF
--- a/web/src/components/app-sidebar.tsx
+++ b/web/src/components/app-sidebar.tsx
@@ -24,44 +24,28 @@ import {
   CollapsibleTrigger,
   CollapsibleContent,
 } from "./ui/collapsible";
+import { useGetUc } from "@/hooks/use-ucs";
 
 export function AppSidebar() {
+  const { data: ucs } = useGetUc();
+
   const items = [
     {
       title: "Manuais",
       icon: BookOpen,
       subContent: [
-        {
-          title: "Manual 1",
-          url: "#",
-        },
-        {
-          title: "Manual 2",
-          url: "#",
-        },
-        {
-          title: "Manual 3",
-          url: "#",
-        },
+        { title: "Manual 1", url: "#" },
+        { title: "Manual 2", url: "#" },
+        { title: "Manual 3", url: "#" },
       ],
     },
     {
       title: "Unidades Curriculares",
       icon: GraduationCap,
-      subContent: [
-        {
-          title: "UC 1",
-          url: "#",
-        },
-        {
-          title: "UC 2",
-          url: "#",
-        },
-        {
-          title: "UC 3",
-          url: "#",
-        },
-      ],
+      subContent: ucs?.map((uc) => ({
+        title: uc.name,
+        url: `/detalhes-uc?ucId=${uc.id}`,
+      })) || [],
     },
   ];
 

--- a/web/src/routes/_layout/detalhes-uc.tsx
+++ b/web/src/routes/_layout/detalhes-uc.tsx
@@ -307,7 +307,10 @@ function RouteComponent() {
               </>
             ) : (
               <>
-                <Link to="/">
+                {/* Ligar este botão "Manuais" quando estiver funcional */}
+                <Link
+                  to="/detalhes-uc"
+                  search={{ ucId: ucId }}>
                   <Button className="cursor-pointer flex flex-row gap-[20px] h-auto w-auto px-[16px] py-[18px] bg-[#41B5C0] border border-[#ffffff] shadow-[0px_4px_4px_0px_rgba(0,0,0,0.25)] active:shadow-none">
                     <span className="w-fit font-medium text-[26px]">
                       Manuais
@@ -332,7 +335,7 @@ function RouteComponent() {
                 >
                   <Button className="cursor-pointer flex flex-row gap-[20px] h-auto w-auto px-[16px] py-[18px] bg-[#2E2B50] border border-[#ffffff] shadow-[0px_4px_4px_0px_rgba(0,0,0,0.25)] active:shadow-none">
                     <span className="w-fit font-medium text-[26px]">
-                      Gerar Exames
+                      Exames
                     </span>
                     <ClipboardList className="size-[50px]" />
                   </Button>


### PR DESCRIPTION
This pull request updates the sidebar to dynamically load curricular units and makes minor UI adjustments in the UC details page. The most important changes are:

**Sidebar functionality:**

* The `AppSidebar` component now fetches curricular units using the `useGetUc` hook and dynamically populates the "Unidades Curriculares" submenu with real data, linking each item to its UC details page.

**UI and navigation improvements in UC details:**

* The "Manuais" button in the UC details page is now set up to navigate to `/detalhes-uc` with the current `ucId` as a search parameter, preparing for future functionality.
* The button previously labeled "Gerar Exames" is now simply labeled "Exames" for clarity.