### PR TITLE
Docs/test and permission documentation

### DIFF
--- a/TEST.md
+++ b/TEST.md
@@ -1,0 +1,632 @@
+# Test Documentation
+
+## Overview
+
+This document provides comprehensive documentation for the Education Platform testing suite, including test structure, current coverage, and guidelines for expanding tests.
+
+---
+
+## Table of Contents
+
+1. [Test Structure](#test-structure)
+2. [Current Tests](#current-tests)
+3. [Unit vs Integration Tests](#unit-vs-integration-tests)
+4. [Running Tests](#running-tests)
+5. [Expanding Tests](#expanding-tests)
+6. [Best Practices](#best-practices)
+
+---
+
+## Test Structure
+
+```
+project/app/
+├── api/
+│   └── tests/
+│       ├── conftest.py                     # Shared fixtures for all tests
+│       ├── unit/                           # Unit tests (in-memory DB, mocked services)
+│       │   ├── conftest.py                 # Unit-specific fixtures
+│       │   ├── test_user.py                # User endpoint tests
+│       │   ├── test_subject.py             # Subject CRUD + Keycloak mock tests
+│       │   ├── test_topic.py               # Topic CRUD tests
+│       │   ├── test_question.py            # Question CRUD tests
+│       │   └── test_exam.py                # Exam generation tests
+│       └── integration/                    # Integration tests (real DB + Keycloak)
+│           ├── conftest.py                 # Integration-specific fixtures
+│           ├── test_auth_integration.py    # Auth flow tests
+│           └── test_full_system.py         # End-to-end system tests
+├── test/                                   # Legacy/manual test scripts
+│   ├── test_api.sh                         # Shell-based API tests
+│   ├── test_prof_end.sh                    # Professor endpoint tests
+│   ├── user_creation.sh                    # User creation test script
+│   └── generate_exam.sh                    # Exam generation test script
+└── run_tests.sh                            # Main test runner script
+```
+
+---
+
+## Current Tests
+
+### Unit Tests (`api/tests/unit/`)
+
+Unit tests use an **in-memory SQLite database** with **mocked external services** (Keycloak). They are fast and isolated.
+
+| Test File | Endpoints Tested | Count | Description |
+|-----------|-----------------|-------|-------------|
+| `test_user.py` | `GET /api/users/me`, `POST /api/users/create` | 4 | User retrieval, creation, authorization, duplicate handling |
+| `test_subject.py` | `POST/GET/PUT/DELETE /api/subjects/*` | 8 | Subject CRUD, authorization, regent validation |
+| `test_topic.py` | `POST/GET /api/topics/*` | 5 | Topic creation, retrieval, subject validation |
+| `test_question.py` | `POST/GET /api/questions/*` | 4 | Question creation, options retrieval, FK validation |
+| `test_exam.py` | `POST /api/exams/generate` | 1 | Exam PDF generation (mocked) |
+
+**Total Unit Tests: 22**
+
+### Integration Tests (`api/tests/integration/`)
+
+Integration tests connect to **real PostgreSQL and Keycloak** instances running in Docker containers.
+
+| Test File | Tests | Description |
+|-----------|-------|-------------|
+| `test_auth_integration.py` | 4 | Health check, auth header validation, subject creation flow with Keycloak group verification |
+| `test_full_system.py` | 1 | Complete end-to-end test: authenticate → create subject → verify Keycloak groups → delete → verify cleanup |
+
+**Total Integration Tests: 5**
+
+### Manual Test Scripts (`test/`)
+
+Legacy shell scripts for manual testing:
+
+| Script | Purpose |
+|--------|---------|
+| `test_api.sh` | Basic API endpoint testing |
+| `test_prof_end.sh` | Professor-specific endpoint tests |
+| `user_creation.sh` | User creation via Keycloak |
+| `generate_exam.sh` | Exam PDF generation test |
+
+---
+
+## Unit vs Integration Tests
+
+### Key Differences
+
+| Aspect | Unit Tests | Integration Tests |
+|--------|------------|-------------------|
+| **Database** | In-memory SQLite (`sqlite+aiosqlite:///:memory:`) | Real PostgreSQL (port 5433) |
+| **Keycloak** | Mocked (`MagicMock`, `AsyncMock`) | Real Keycloak instance (port 8081) |
+| **External Services** | All mocked | Real services |
+| **Speed** | Fast (< 1 second per test) | Slow (5-30 seconds per test) |
+| **Isolation** | Fully isolated | Depends on Docker services |
+| **Use Case** | Logic validation, edge cases | End-to-end flow validation |
+| **Setup** | No external dependencies | Requires `docker-compose.test.yml` |
+
+### When to Use Each
+
+**Unit Tests:**
+- Testing business logic in isolation
+- Validating edge cases and error handling
+- Quick feedback during development
+- Testing authorization/permission logic
+- Mocking external API responses
+
+**Integration Tests:**
+- Validating real database interactions
+- Testing Keycloak group creation/deletion
+- Verifying end-to-end user flows
+- Testing transaction rollback
+- Validating foreign key constraints
+
+### Test Isolation
+
+The test suite uses **Docker project namespacing** to avoid conflicts:
+
+```bash
+# Test environment (isolated)
+docker compose -p edupro-test -f deployment/docker-compose.test.yml
+
+# Ports used by tests:
+# - PostgreSQL: 5433 (host) -> 5432 (container)
+# - Keycloak:   8081 (host) -> 8080 (container)
+```
+
+---
+
+## Running Tests
+
+### Prerequisites
+
+1. **Docker and Docker Compose** installed
+2. **UV package manager** for Python dependencies
+3. **Python 3.12+**
+
+### Running All Tests
+
+```bash
+# From project root
+./run_tests.sh
+```
+
+This script:
+1. Starts isolated Docker services (DB on 5433, Keycloak on 8081)
+2. Waits for services to be ready
+3. Runs unit tests
+4. Runs integration tests
+5. Cleans up
+
+### Running Tests Manually
+
+```bash
+# Start test infrastructure
+docker compose -p edupro-test -f deployment/docker-compose.test.yml up -d
+
+# Wait for services (check logs)
+docker compose -p edupro-test -f deployment/docker-compose.test.yml logs -f
+
+# Run unit tests only
+cd api
+PYTHONPATH=. uv run pytest tests/unit
+
+# Run integration tests only
+cd api
+PYTHONPATH=. POSTGRES_PORT=5433 KEYCLOAK_SERVER_URL="http://localhost:8081" \
+  uv run pytest tests/integration
+
+# Run specific test file
+uv run pytest tests/unit/test_subject.py -v
+
+# Run specific test function
+uv run pytest tests/unit/test_subject.py::test_create_subject -v
+
+# Run with coverage
+uv run pytest --cov=src --cov-report=html
+
+# Run with output (print statements)
+uv run pytest -s
+
+# Run tests matching a pattern
+uv run pytest -k "subject"
+```
+
+### Stopping Test Services
+
+```bash
+# Stop and remove all test containers and volumes
+docker compose -p edupro-test -f deployment/docker-compose.test.yml down -v
+```
+
+---
+
+## Expanding Tests
+
+### Adding a New Unit Test
+
+**Example: Testing a new `PATCH /api/subjects/{id}` endpoint**
+
+```python
+# tests/unit/test_subject.py
+
+@pytest.mark.asyncio
+async def test_partial_update_subject(client, mock_auth, session):
+    """Test PATCH endpoint for partial subject updates."""
+    app.dependency_overrides[get_current_user_info] = mock_auth
+
+    # 1. Create initial subject
+    from src.models.subject import Subject
+    subject = Subject(name="Original Name", description="Original desc")
+    session.add(subject)
+    await session.commit()
+    await session.refresh(subject)
+
+    # 2. Patch only the description
+    response = await client.patch(
+        f"/api/subjects/{subject.id}",
+        json={"description": "Updated description"}
+    )
+
+    # 3. Assert response
+    assert response.status_code == 200
+    data = response.json()
+    assert data["description"] == "Updated description"
+    assert data["name"] == "Original Name"  # Unchanged
+
+    # 4. Assert database state
+    updated = await session.get(Subject, subject.id)
+    assert updated.description == "Updated description"
+```
+
+### Adding a New Integration Test
+
+**Example: Testing student enrollment flow**
+
+```python
+# tests/integration/test_student_enrollment.py
+
+import pytest
+import uuid
+from src.core.settings import settings
+
+@pytest.mark.asyncio
+async def test_enroll_student_in_subject(integration_client, manager_token, edupro_admin):
+    """
+    Integration test for enrolling a student in a subject.
+    Validates Keycloak group membership after enrollment.
+    """
+    headers = {"Authorization": f"Bearer {manager_token}"}
+
+    # 1. Create a test student
+    student_username = f"test_student_{uuid.uuid4().hex[:8]}"
+    student_data = {
+        "username": student_username,
+        "email": f"{student_username}@test.com",
+        "password": "testpass123",
+        "first_name": "Test",
+        "last_name": "Student",
+        "realm_role": "student"
+    }
+
+    create_response = await integration_client.post(
+        "/api/users/create",
+        json=student_data,
+        headers=headers
+    )
+    assert create_response.status_code == 200
+    student_id = create_response.json()["user_id"]
+
+    # 2. Create a subject
+    subject_name = f"Enrollment Test Subject {uuid.uuid4().hex[:6]}"
+    subject_response = await integration_client.post(
+        "/api/subjects/",
+        json={"name": subject_name, "regent_keycloak_id": student_id},
+        headers=headers
+    )
+    assert subject_response.status_code == 200
+    subject_id = subject_response.json()["id"]
+
+    # 3. Enroll student in subject (new endpoint)
+    enroll_payload = {"student_ids": [student_id]}
+    enroll_response = await integration_client.post(
+        f"/api/subjects/{subject_id}/enroll",
+        json=enroll_payload,
+        headers=headers
+    )
+    assert enroll_response.status_code == 200
+
+    # 4. Verify Keycloak group membership
+    expected_student_group = f"s{subject_id}/students"
+    groups = edupro_admin.get_groups()
+    student_group = next((g for g in groups if g['name'] == expected_student_group), None)
+
+    assert student_group is not None, f"Group {expected_student_group} not found"
+
+    members = edupro_admin.get_group_members(student_group['id'])
+    member_ids = [m['id'] for m in members]
+    assert student_id in member_ids, "Student not found in subject students group"
+```
+
+### Testing a New Model
+
+**Step 1: Create unit test file**
+
+```python
+# tests/unit/test_workbook.py
+
+import pytest
+from src.core.deps import get_current_user_info
+from src.main import app
+
+@pytest.fixture
+async def setup_subject(session):
+    """Create a subject for workbook tests."""
+    from src.models.subject import Subject
+    sub = Subject(name="Workbook Subject")
+    session.add(sub)
+    await session.commit()
+    await session.refresh(sub)
+    return sub
+
+@pytest.mark.asyncio
+async def test_create_workbook(client, mock_auth, setup_subject):
+    """Test workbook creation."""
+    app.dependency_overrides[get_current_user_info] = mock_auth
+    subject = setup_subject
+
+    payload = {
+        "subject_id": subject.id,
+        "title": "Test Workbook",
+        "description": "A test workbook"
+    }
+
+    response = await client.post("/api/workbooks/", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["title"] == "Test Workbook"
+    assert "id" in data
+
+@pytest.mark.asyncio
+async def test_get_workbooks_by_subject(client, session, setup_subject):
+    """Test retrieving workbooks by subject."""
+    from src.models.workbook import Workbook
+
+    # Create multiple workbooks
+    for i in range(3):
+        wb = Workbook(
+            subject_id=setup_subject.id,
+            title=f"Workbook {i}",
+            description=f"Description {i}"
+        )
+        session.add(wb)
+    await session.commit()
+
+    response = await client.get(f"/api/workbooks/subject/{setup_subject.id}")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 3
+    titles = [w["title"] for w in data]
+    assert "Workbook 0" in titles
+    assert "Workbook 1" in titles
+    assert "Workbook 2" in titles
+```
+
+### Mocking Keycloak in Unit Tests
+
+When testing endpoints that interact with Keycloak:
+
+```python
+@pytest.mark.asyncio
+async def test_endpoint_with_keycloak(client, mock_auth):
+    app.dependency_overrides[get_current_user_info] = mock_auth
+
+    from src.core.keycloak import keycloak_client
+    from unittest.mock import AsyncMock
+
+    # Mock specific Keycloak methods
+    with pytest.MonkeyPatch.context() as mp:
+        # Mock create_user_in_keycloak
+        mp.setattr(
+            keycloak_client,
+            "create_user_in_keycloak",
+            AsyncMock(return_value={"user_id": "new-id", "message": "created"})
+        )
+
+        # Mock get_user_by_email
+        mp.setattr(
+            keycloak_client,
+            "get_user_by_email",
+            AsyncMock(return_value={"id": "existing-id", "email": "test@test.com"})
+        )
+
+        response = await client.post("/api/users/create", json={...})
+        assert response.status_code == 200
+```
+
+### Testing Error Cases
+
+```python
+@pytest.mark.asyncio
+async def test_create_subject_with_invalid_regent(client, mock_auth):
+    """Test error handling when regent user doesn't exist."""
+    app.dependency_overrides[get_current_user_info] = mock_auth
+
+    from unittest.mock import patch
+    from fastapi import HTTPException
+
+    # Mock verify_regent_exists to raise exception
+    with patch(
+        "src.services.subject.verify_regent_exists",
+        side_effect=HTTPException(
+            status_code=400,
+            detail="Regent user with ID 'invalid-id' not found."
+        )
+    ):
+        response = await client.post(
+            "/api/subjects/",
+            json={"name": "Bad Subject", "regent_keycloak_id": "invalid-id"}
+        )
+
+        assert response.status_code == 400
+        assert "Regent user" in response.json()["detail"]
+
+@pytest.mark.asyncio
+async def test_delete_nonexistent_subject(client, mock_auth):
+    """Test 404 when deleting a subject that doesn't exist."""
+    app.dependency_overrides[get_current_user_info] = mock_auth
+
+    response = await client.delete("/api/subjects/99999")
+    assert response.status_code == 404
+```
+
+---
+
+## Best Practices
+
+### Test Naming Conventions
+
+```python
+# Use descriptive names following this pattern:
+test_<action>_<entity>_<condition>()
+
+# Examples:
+test_create_subject_success()
+test_create_subject_unauthorized()
+test_create_subject_invalid_regent()
+test_get_subject_not_found()
+test_delete_subject_cascades_to_topics()
+```
+
+### Fixture Organization
+
+```python
+# conftest.py - Shared fixtures
+
+@pytest.fixture
+def manager_user():
+    """Create a mock manager user."""
+    return User(
+        user_id="manager-id-123",
+        username="manager",
+        email="manager@example.com",
+        realm_roles=["manager"],
+        groups=[]
+    )
+
+@pytest_asyncio.fixture
+async def session(engine):
+    """Create an async database session."""
+    # Setup
+    yield session
+    # Teardown
+```
+
+### Test Data Setup
+
+```python
+# Always clean up after tests
+@pytest.mark.asyncio
+async def test_something(client, session):
+    # Create test data
+    item = TestModel(name="Test")
+    session.add(item)
+    await session.commit()
+
+    try:
+        # Run test
+        response = await client.get(f"/api/items/{item.id}")
+        assert response.status_code == 200
+    finally:
+        # Cleanup (if not using transaction rollback)
+        await session.delete(item)
+        await session.commit()
+```
+
+### Using Parametrization
+
+```python
+import pytest
+
+@pytest.mark.parametrize("role,expected_status", [
+    ("manager", 200),
+    ("professor", 200),
+    ("student", 403),
+])
+@pytest.mark.asyncio
+async def test_create_subject_by_role(client, role, expected_status):
+    """Test subject creation with different user roles."""
+
+    user = User(
+        user_id=f"{role}-id",
+        username=role,
+        email=f"{role}@test.com",
+        realm_roles=[role],
+        groups=[]
+    )
+
+    async def mock_user():
+        return user
+
+    app.dependency_overrides[get_current_user_info] = mock_user
+
+    response = await client.post("/api/subjects/", json={"name": "Test"})
+    assert response.status_code == expected_status
+```
+
+### Testing Async Code
+
+```python
+# Always use @pytest.mark.asyncio decorator
+@pytest.mark.asyncio
+async def test_async_endpoint(client):
+    response = await client.get("/api/async-endpoint")
+    assert response.status_code == 200
+
+# Use pytest_asyncio.fixture for async fixtures
+@pytest_asyncio.fixture
+async def async_data():
+    data = await fetch_data()
+    yield data
+```
+
+### Coverage Goals
+
+Aim for:
+- **80%+ line coverage** on `src/` directory
+- **100% coverage** on critical paths (auth, permissions)
+- **At least 1 unit test** per endpoint
+- **At least 1 integration test** per major flow
+
+Check coverage:
+
+```bash
+uv run pytest --cov=src --cov-report=term-missing
+```
+
+---
+
+## Troubleshooting
+
+### Common Issues
+
+**1. Tests fail with "database is locked"**
+
+```bash
+# Ensure no other test is running
+docker compose -p edupro-test down -v
+
+# Clear any leftover volumes
+docker volume ls | grep edupro-test
+docker volume rm edupro-test_db_data
+```
+
+**2. Keycloak connection timeout**
+
+```bash
+# Check Keycloak is running
+docker compose -p edupro-test ps
+
+# View Keycloak logs
+docker compose -p edupro-test logs keycloak
+
+# Increase wait time in run_tests.sh if needed
+```
+
+**3. Import errors in tests**
+
+```bash
+# Ensure PYTHONPATH is set
+export PYTHONPATH=.
+
+# Or run with uv
+uv run pytest tests/unit/test_subject.py
+```
+
+**4. Async test hangs**
+
+```python
+# Ensure you're using the decorator
+@pytest.mark.asyncio
+async def test_something():
+    ...
+
+# Check pytest-asyncio is installed
+uv pip list | grep pytest-asyncio
+```
+
+---
+
+## Future Improvements
+
+- [ ] Add frontend tests (React Testing Library)
+- [ ] Add E2E tests (Playwright or Cypress)
+- [ ] Add performance/load tests
+- [ ] Add API contract tests
+- [ ] Add snapshot tests for PDF generation
+- [ ] Integrate with CI/CD pipeline
+- [ ] Add test coverage reporting (Codecov, Coveralls)
+
+---
+
+## References
+
+- [pytest Documentation](https://docs.pytest.org/)
+- [pytest-asyncio Documentation](https://pytest-asyncio.readthedocs.io/)
+- [FastAPI Testing](https://fastapi.tiangolo.com/tutorial/testing/)
+- [SQLModel Testing](https://sqlmodel.tiangolo.com/tutorial/testing/)
+- [httpx AsyncClient](https://www.python-httpx.org/async/)

--- a/api/permissions.md
+++ b/api/permissions.md
@@ -328,7 +328,7 @@ async def create_topic(
 | Create questions (own subject) | ❌ | ✅ | ⚠️ | ❌ |
 | Generate exams (own subject) | ❌ | ✅ | ⚠️ | ❌ |
 | View own subjects | ✅ | ✅ | ✅ | ✅ |
-| View questions | ❌ | ✅ | ✅ | ⚠️ |
+| View questions | ❌ | ✅ | ⚠️ | ❌ |
 
 **Legend:**
 - ✅ = Full access

--- a/api/permissions.md
+++ b/api/permissions.md
@@ -118,13 +118,6 @@ Students have **read-only access** to subjects they are enrolled in.
 | `/api/users/students` | GET | List all students |
 | `/api/subjects/` | GET | List enrolled subjects |
 | `/api/subjects/{id}` | GET | Get subject details |
-| `/api/subjects/{id}/topics` | GET | Get topics |
-| `/api/subjects/{id}/topics-list` | GET | Get topics list |
-| `/api/subjects/{id}/all-questions` | GET | View questions (if permitted) |
-| `/api/topics/{id}` | GET | Get topic details |
-| `/api/questions/{id}` | GET | Get question (view only) |
-| `/api/questions/{id}/question-options` | GET | View question options |
-| `/api/exams/subject/{id}/configs` | GET | View exam configs |
 
 ---
 

--- a/api/permissions.md
+++ b/api/permissions.md
@@ -15,7 +15,7 @@ This document details the role-based access control (RBAC) system for the Educat
 
 | Role | Description | Scope |
 |------|-------------|-------|
-| `manager` | Platform administrators | Global - all subjects |
+| `manager` | Platform administrators | Global - all subjects, but only for administrative actions |
 | `professor` | Teaching staff | Subject-specific via groups |
 | `student` | Students | Subject-specific via groups |
 
@@ -25,7 +25,7 @@ This document details the role-based access control (RBAC) system for the Educat
 
 **Realm Role:** `manager`
 
-Managers have **full access** to all endpoints and all subjects. They bypass group-based restrictions.
+Managers have **administrative access** to the platform. They can manage subjects, users, enrollments, and roles. However, **they do not have implicit access to subject content** (topics, questions, exams).
 
 #### Endpoints Accessible by Managers
 
@@ -38,32 +38,14 @@ Managers have **full access** to all endpoints and all subjects. They bypass gro
 | `/api/users/debug/token-info` | GET | Debug token information |
 | `/api/subjects/` | POST | Create new subjects |
 | `/api/subjects/` | GET | List all subjects |
-| `/api/subjects/{id}` | GET | Get any subject |
 | `/api/subjects/{id}` | PUT | Update any subject |
 | `/api/subjects/{id}` | DELETE | Delete any subject |
 | `/api/subjects/{id}/students` | GET | View enrolled students |
 | `/api/subjects/{id}/professors` | GET | View enrolled professors |
-| `/api/subjects/{id}/regent` | GET | View subject regent |
 | `/api/subjects/{id}/students` | POST | Add students to subject |
 | `/api/subjects/{id}/professors` | POST | Add professor to subject |
 | `/api/subjects/{id}/professors/{prof_id}` | PUT | Update professor permissions |
 | `/api/subjects/{id}/professors/{prof_id}` | DELETE | Remove professor from subject |
-| `/api/subjects/{id}/topics` | GET | Get all topics with question counts |
-| `/api/subjects/{id}/topics-list` | GET | Get topics list |
-| `/api/subjects/{id}/all-questions` | GET | Get all questions |
-| `/api/topics/` | POST | Create topics |
-| `/api/topics/{id}` | PUT | Update topics |
-| `/api/topics/{id}` | DELETE | Delete topics |
-| `/api/questions/` | POST | Create questions |
-| `/api/questions/{id}` | GET | Get question |
-| `/api/questions/{id}` | PUT | Update question |
-| `/api/questions/{id}` | DELETE | Delete question |
-| `/api/questions/{id}/question-options` | GET | Get question options |
-| `/api/question-options/` | POST | Create question options |
-| `/api/question-options/{id}` | PUT | Update option |
-| `/api/question-options/{id}` | DELETE | Delete option |
-| `/api/exams/generate` | POST | Generate exams |
-| `/api/exams/subject/{id}/configs` | GET | Get exam configs |
 
 ---
 
@@ -97,25 +79,21 @@ Professors have **subject-specific access** based on group membership. They must
 | `/api/subjects/{id}/students` | GET | `/professors`, `/regent` | View enrolled students |
 | `/api/subjects/{id}/professors` | GET | `/professors`, `/regent` | View enrolled professors |
 | `/api/subjects/{id}/regent` | GET | Any subject group | View subject regent |
-| `/api/subjects/{id}/students` | POST | `/add_students`, Manager, Regent | Add students |
-| `/api/subjects/{id}/professors` | POST | Manager, Regent | Add professor |
-| `/api/subjects/{id}/professors/{prof_id}` | PUT | Manager, Regent | Update professor permissions |
-| `/api/subjects/{id}/professors/{prof_id}` | DELETE | Manager, Regent | Remove professor |
 | `/api/subjects/{id}/topics` | GET | Any subject group | Get topics |
 | `/api/subjects/{id}/topics-list` | GET | Any subject group | Get topics list |
 | `/api/subjects/{id}/all-questions` | GET | Any subject group | Get all questions |
-| `/api/topics/` | POST | `/edit_topics`, Regent | Create topics |
-| `/api/topics/{id}` | PUT | `/edit_topics`, Regent | Update topics |
-| `/api/topics/{id}` | DELETE | `/edit_topics`, Regent | Delete topics |
-| `/api/questions/` | POST | `/edit_questions`, Regent | Create questions |
+| `/api/topics/` | POST | `/edit_topics`, `/regent` | Create topics |
+| `/api/topics/{id}` | PUT | `/edit_topics`, `/regent` | Update topics |
+| `/api/topics/{id}` | DELETE | `/edit_topics`, `/regent` | Delete topics |
+| `/api/questions/` | POST | `/edit_questions`, `/regent` | Create questions |
 | `/api/questions/{id}` | GET | Any subject group | Get question |
-| `/api/questions/{id}` | PUT | `/edit_questions`, Regent | Update question |
-| `/api/questions/{id}` | DELETE | `/edit_questions`, Regent | Delete question |
+| `/api/questions/{id}` | PUT | `/edit_questions`, `/regent` | Update question |
+| `/api/questions/{id}` | DELETE | `/edit_questions`, `/regent` | Delete question |
 | `/api/questions/{id}/question-options` | GET | Any subject group | Get question options |
-| `/api/question-options/` | POST | `/edit_questions`, Regent | Create options |
-| `/api/question-options/{id}` | PUT | `/edit_questions`, Regent | Update option |
-| `/api/question-options/{id}` | DELETE | `/edit_questions`, Regent | Delete option |
-| `/api/exams/generate` | POST | `/generate_exams` | Generate exams |
+| `/api/question-options/` | POST | `/edit_questions`, `/regent` | Create options |
+| `/api/question-options/{id}` | PUT | `/edit_questions`, `/regent` | Update option |
+| `/api/question-options/{id}` | DELETE | `/edit_questions`, `/regent` | Delete option |
+| `/api/exams/generate` | POST | `/generate_exams`, `/regent` | Generate exams |
 | `/api/exams/subject/{id}/configs` | GET | Any subject group | Get exam configs |
 
 ---
@@ -143,7 +121,6 @@ Students have **read-only access** to subjects they are enrolled in.
 | `/api/subjects/{id}/topics` | GET | Get topics |
 | `/api/subjects/{id}/topics-list` | GET | Get topics list |
 | `/api/subjects/{id}/all-questions` | GET | View questions (if permitted) |
-| `/api/topics/` | GET | List all topics |
 | `/api/topics/{id}` | GET | Get topic details |
 | `/api/questions/{id}` | GET | Get question (view only) |
 | `/api/questions/{id}/question-options` | GET | View question options |
@@ -173,7 +150,7 @@ Regents have **full management** over their assigned subject:
 
 #### Endpoints Accessible by Regents
 
-Same as professors with **all permission groups** automatically granted for their subject.
+Same as professors with **all permission groups** directly evaluated via `verify_permission`.
 
 ---
 
@@ -208,19 +185,19 @@ Same as professors with **all permission groups** automatically granted for thei
 |----------|--------|---------------------|-------------|
 | `/api/subjects/` | POST | `manager` role | Create new subject |
 | `/api/subjects/` | GET | Authenticated | List accessible subjects |
-| `/api/subjects/{id}` | GET | Subject group member | Get subject by ID |
+| `/api/subjects/{id}` | GET | Subject group member (`/s{id}`) | Get subject by ID |
 | `/api/subjects/{id}` | PUT | `manager` role | Update subject |
 | `/api/subjects/{id}` | DELETE | `manager` role | Delete subject |
-| `/api/subjects/{id}/students` | GET | `manager`, `/regent`, `/professors` | View students |
-| `/api/subjects/{id}/professors` | GET | `manager`, `/regent`, `/professors` | View professors |
-| `/api/subjects/{id}/regent` | GET | Subject group member | View regent |
-| `/api/subjects/{id}/students` | POST | `manager`, `/regent`, `/add_students` | Add students |
-| `/api/subjects/{id}/professors` | POST | `manager`, `/regent` | Add professor |
-| `/api/subjects/{id}/professors/{prof_id}` | PUT | `manager`, `/regent` | Update professor permissions |
-| `/api/subjects/{id}/professors/{prof_id}` | DELETE | `manager`, `/regent` | Remove professor |
-| `/api/subjects/{id}/topics` | GET | Subject group member | Get topics with question counts |
-| `/api/subjects/{id}/topics-list` | GET | Subject group member | Get topics list |
-| `/api/subjects/{id}/all-questions` | GET | Subject group member | Get all questions and options |
+| `/api/subjects/{id}/students` | GET | `manager`, `/s{id}/professors`, `/s{id}/regent` | View students |
+| `/api/subjects/{id}/professors` | GET | `manager`, `/s{id}/professors`, `/s{id}/regent` | View professors |
+| `/api/subjects/{id}/regent` | GET | Subject group member (`/s{id}`) | View regent |
+| `/api/subjects/{id}/students` | POST | `manager`, `/s{id}/add_students`, `/s{id}/regent` | Add students |
+| `/api/subjects/{id}/professors` | POST | `manager`, `/s{id}/regent` | Add professor |
+| `/api/subjects/{id}/professors/{prof_id}` | PUT | `manager`, `/s{id}/regent` | Update professor permissions |
+| `/api/subjects/{id}/professors/{prof_id}` | DELETE | `manager`, `/s{id}/regent` | Remove professor |
+| `/api/subjects/{id}/topics` | GET | Subject group member (`/s{id}`) | Get topics with question counts |
+| `/api/subjects/{id}/topics-list` | GET | Subject group member (`/s{id}`) | Get topics list |
+| `/api/subjects/{id}/all-questions` | GET | Subject group member (`/s{id}`) | Get all questions and options |
 
 ---
 
@@ -228,11 +205,10 @@ Same as professors with **all permission groups** automatically granted for thei
 
 | Endpoint | Method | Required Permission | Description |
 |----------|--------|---------------------|-------------|
-| `/api/topics/` | POST | `/edit_topics`, Regent | Create topic |
-| `/api/topics/` | GET | Authenticated | List all topics |
-| `/api/topics/{id}` | GET | Authenticated | Get topic by ID |
-| `/api/topics/{id}` | PUT | `/edit_topics`, Regent | Update topic |
-| `/api/topics/{id}` | DELETE | `/edit_topics`, Regent | Delete topic |
+| `/api/topics/` | POST | `/s{id}/edit_topics`, `/s{id}/regent` | Create topic |
+| `/api/topics/{id}` | GET | Subject group member (`/s{id}`) | Get topic by ID |
+| `/api/topics/{id}` | PUT | `/s{id}/edit_topics`, `/s{id}/regent` | Update topic |
+| `/api/topics/{id}` | DELETE | `/s{id}/edit_topics`, `/s{id}/regent` | Delete topic |
 
 ---
 
@@ -240,12 +216,12 @@ Same as professors with **all permission groups** automatically granted for thei
 
 | Endpoint | Method | Required Permission | Description |
 |----------|--------|---------------------|-------------|
-| `/api/questions/` | POST | `/edit_questions`, Regent | Create questions |
-| `/api/questions/{subject_id}/XML` | POST | `/edit_questions`, Regent | Create questions from XML |
-| `/api/questions/{id}` | GET | Authenticated | Get question by ID |
-| `/api/questions/{id}` | PUT | `/edit_questions`, Regent | Update question |
-| `/api/questions/{id}` | DELETE | `/edit_questions`, Regent | Delete question |
-| `/api/questions/{id}/question-options` | GET | Authenticated | Get question options |
+| `/api/questions/` | POST | `/s{id}/edit_questions`, `/s{id}/regent` | Create questions |
+| `/api/questions/{subject_id}/XML` | POST | `/s{id}/edit_questions`, `/s{id}/regent` | Create questions from XML |
+| `/api/questions/{id}` | GET | Subject group member (`/s{id}`) | Get question by ID |
+| `/api/questions/{id}` | PUT | `/s{id}/edit_questions`, `/s{id}/regent` | Update question |
+| `/api/questions/{id}` | DELETE | `/s{id}/edit_questions`, `/s{id}/regent` | Delete question |
+| `/api/questions/{id}/question-options` | GET | Subject group member (`/s{id}`) | Get question options |
 
 ---
 
@@ -253,9 +229,9 @@ Same as professors with **all permission groups** automatically granted for thei
 
 | Endpoint | Method | Required Permission | Description |
 |----------|--------|---------------------|-------------|
-| `/api/question-options/` | POST | `/edit_questions`, Regent | Create question options |
-| `/api/question-options/{id}` | PUT | `/edit_questions`, Regent | Update option |
-| `/api/question-options/{id}` | DELETE | `/edit_questions`, Regent | Delete option |
+| `/api/question-options/` | POST | `/s{id}/edit_questions`, `/s{id}/regent` | Create question options |
+| `/api/question-options/{id}` | PUT | `/s{id}/edit_questions`, `/s{id}/regent` | Update option |
+| `/api/question-options/{id}` | DELETE | `/s{id}/edit_questions`, `/s{id}/regent` | Delete option |
 
 ---
 
@@ -263,8 +239,8 @@ Same as professors with **all permission groups** automatically granted for thei
 
 | Endpoint | Method | Required Permission | Description |
 |----------|--------|---------------------|-------------|
-| `/api/exams/generate` | POST | `/generate_exams` | Generate exam PDFs |
-| `/api/exams/subject/{id}/configs` | GET | Subject group member | Get exam configurations |
+| `/api/exams/generate` | POST | `/s{id}/generate_exams`, `/s{id}/regent` | Generate exam PDFs |
+| `/api/exams/subject/{id}/configs` | GET | Subject group member (`/s{id}`) | Get exam configurations |
 
 ---
 
@@ -288,45 +264,39 @@ s{subject_id}/                    # Base subject group
 
 ## Permission Check Implementation
 
-### Role-Based Check
-
-```python
-from src.core.deps import require_manager
-
-@router.post("/", dependencies=[Depends(require_manager)])
-async def create_subject():
-    # Only managers can access
-```
-
-### Group-Based Check
-
-```python
-from src.core.deps import require_group
-
-@router.post("/students")
-async def add_students(
-    user: User = Depends(require_group("/s123/add_students"))
-):
-    # Only users in s123/add_students group can access
-```
-
 ### Custom Permission Check
 
-```python
-from src.core.deps import get_current_user_info
+Permissions are enforced using the `verify_permission` function, checking if the authenticated user has one of a required list of permissions. 
 
-@router.get("/{subject_id}/students")
-async def get_students(
+```python
+from src.core.deps import get_current_user_info, verify_permission
+
+@router.post("/{subject_id}/students")
+async def add_students(
     subject_id: int,
     user_info: User = Depends(get_current_user_info)
 ):
-    roles = user_info.realm_roles
-    groups = user_info.groups
+    # Checking if the user possesses `/s{id}/add_students`, `/s{id}/regent`, or is a global `manager`
+    verify_permission(
+        user_info, 
+        [f"/s{subject_id}/add_students", f"/s{subject_id}/regent"], 
+        allow_manager=True
+    )
+```
 
-    if not ("manager" in roles or
-            any(g.endswith(f"s{subject_id}/regent") for g in groups) or
-            any(g.endswith(f"s{subject_id}/professors") for g in groups)):
-        raise HTTPException(status_code=403, detail="Access denied")
+```python
+from src.core.deps import get_current_user_info, verify_permission
+
+@router.post("/topics/")
+async def create_topic(
+    topic_data: TopicCreate,
+    user_info: User = Depends(get_current_user_info)
+):
+    # Only checks explicit groups (Managers are implicitly denied unless they belong to the groups)
+    verify_permission(
+        user_info, 
+        [f"/s{topic_data.subject_id}/edit_topics", f"/s{topic_data.subject_id}/regent"]
+    )
 ```
 
 ---
@@ -337,7 +307,7 @@ async def get_students(
 2. **Keycloak returns JWT** with roles and groups
 3. **Frontend includes token** in `Authorization: Bearer <token>` header
 4. **API verifies token** using `get_current_user_info` dependency
-5. **Permission checks** validate roles/groups before executing endpoint
+5. **Permission checks** validate roles/groups before executing endpoint using `verify_permission`
 
 ---
 
@@ -347,8 +317,6 @@ async def get_students(
 |-------------|---------|----------|
 | `401` | Not authenticated | `{"detail": "Not authenticated"}` |
 | `401` | Invalid token | `{"detail": "Invalid token"}` |
-| `403` | Missing role | `{"detail": "Requires {role} role"}` |
-| `403` | Missing group | `{"detail": "Requires membership in group {group}"}` |
 | `403` | Custom denial | `{"detail": "Access denied"}` |
 
 ---
@@ -362,46 +330,14 @@ async def get_students(
 | Create subjects | ✅ | ❌ | ❌ | ❌ |
 | Update/Delete any subject | ✅ | ❌ | ❌ | ❌ |
 | Create users | ✅ | ❌ | ❌ | ❌ |
-| Create topics (own subject) | ✅ | ✅ | ⚠️ | ❌ |
-| Create questions (own subject) | ✅ | ✅ | ⚠️ | ❌ |
-| Add students (own subject) | ✅ | ✅ | ⚠️ | ❌ |
-| Generate exams (own subject) | ✅ | ✅ | ⚠️ | ❌ |
+| Add students/professors to any subject | ✅ | ✅ | ⚠️ | ❌ |
+| Create topics (own subject) | ❌ | ✅ | ⚠️ | ❌ |
+| Create questions (own subject) | ❌ | ✅ | ⚠️ | ❌ |
+| Generate exams (own subject) | ❌ | ✅ | ⚠️ | ❌ |
 | View own subjects | ✅ | ✅ | ✅ | ✅ |
-| View questions | ✅ | ✅ | ✅ | ⚠️ |
+| View questions | ❌ | ✅ | ✅ | ⚠️ |
 
 **Legend:**
 - ✅ = Full access
 - ⚠️ = Requires specific permission group
 - ❌ = No access
-
----
-
-## Adding New Permissions
-
-To add a new permission group:
-
-1. **Add group to Keycloak** when creating subject:
-```python
-subgroups = [
-    "regent", "students", "professors",
-    "edit_topics", "edit_questions",
-    "view_question_bank", "add_students",
-    "generate_exams", "view_grades",
-    "auto_correct_exams",
-    "NEW_PERMISSION"  # Add here
-]
-```
-
-2. **Create dependency** in `src/core/deps.py`:
-```python
-def require_new_permission(subject_id: str):
-    group_name = f"/s{subject_id}/NEW_PERMISSION"
-    return require_group(group_name)
-```
-
-3. **Apply to endpoint**:
-```python
-@router.post("/new-feature", dependencies=[Depends(require_new_permission)])
-async def new_feature():
-    ...
-```

--- a/api/permissions.md
+++ b/api/permissions.md
@@ -40,6 +40,7 @@ Managers have **administrative access** to the platform. They can manage subject
 | `/api/subjects/` | GET | List all subjects |
 | `/api/subjects/{id}` | PUT | Update any subject |
 | `/api/subjects/{id}` | DELETE | Delete any subject |
+| `/api/subjects/{id}/regent` | GET | View subject regent |
 | `/api/subjects/{id}/students` | GET | View enrolled students |
 | `/api/subjects/{id}/professors` | GET | View enrolled professors |
 | `/api/subjects/{id}/students` | POST | Add students to subject |
@@ -183,7 +184,7 @@ Same as professors with **all permission groups** directly evaluated via `verify
 | `/api/subjects/{id}` | DELETE | `manager` role | Delete subject |
 | `/api/subjects/{id}/students` | GET | `manager`, `/s{id}/professors`, `/s{id}/regent` | View students |
 | `/api/subjects/{id}/professors` | GET | `manager`, `/s{id}/professors`, `/s{id}/regent` | View professors |
-| `/api/subjects/{id}/regent` | GET | Subject group member (`/s{id}`) | View regent |
+| `/api/subjects/{id}/regent` | GET | `manager`, Subject group member (`/s{id}`) | View regent |
 | `/api/subjects/{id}/students` | POST | `manager`, `/s{id}/add_students`, `/s{id}/regent` | Add students |
 | `/api/subjects/{id}/professors` | POST | `manager`, `/s{id}/regent` | Add professor |
 | `/api/subjects/{id}/professors/{prof_id}` | PUT | `manager`, `/s{id}/regent` | Update professor permissions |

--- a/api/permissions.md
+++ b/api/permissions.md
@@ -79,9 +79,9 @@ Professors have **subject-specific access** based on group membership. They must
 | `/api/subjects/{id}/students` | GET | `/professors`, `/regent` | View enrolled students |
 | `/api/subjects/{id}/professors` | GET | `/professors`, `/regent` | View enrolled professors |
 | `/api/subjects/{id}/regent` | GET | Any subject group | View subject regent |
-| `/api/subjects/{id}/topics` | GET | Any subject group | Get topics |
-| `/api/subjects/{id}/topics-list` | GET | Any subject group | Get topics list |
-| `/api/subjects/{id}/all-questions` | GET | Any subject group | Get all questions |
+| `/api/subjects/{id}/topics` | GET | `/view_question_bank`, `/regent` | Get topics |
+| `/api/subjects/{id}/topics-list` | GET | `/view_question_bank`, `/regent` | Get topics list |
+| `/api/subjects/{id}/all-questions` | GET | `/view_question_bank`, `/regent` | Get all questions |
 | `/api/topics/` | POST | `/edit_topics`, `/regent` | Create topics |
 | `/api/topics/{id}` | PUT | `/edit_topics`, `/regent` | Update topics |
 | `/api/topics/{id}` | DELETE | `/edit_topics`, `/regent` | Delete topics |
@@ -195,9 +195,9 @@ Same as professors with **all permission groups** directly evaluated via `verify
 | `/api/subjects/{id}/professors` | POST | `manager`, `/s{id}/regent` | Add professor |
 | `/api/subjects/{id}/professors/{prof_id}` | PUT | `manager`, `/s{id}/regent` | Update professor permissions |
 | `/api/subjects/{id}/professors/{prof_id}` | DELETE | `manager`, `/s{id}/regent` | Remove professor |
-| `/api/subjects/{id}/topics` | GET | Subject group member (`/s{id}`) | Get topics with question counts |
-| `/api/subjects/{id}/topics-list` | GET | Subject group member (`/s{id}`) | Get topics list |
-| `/api/subjects/{id}/all-questions` | GET | Subject group member (`/s{id}`) | Get all questions and options |
+| `/api/subjects/{id}/topics` | GET | `/s{id}/view_question_bank`, `/s{id}/regent` | Get topics with question counts |
+| `/api/subjects/{id}/topics-list` | GET | `/s{id}/view_question_bank`, `/s{id}/regent` | Get topics list |
+| `/api/subjects/{id}/all-questions` | GET | `/s{id}/view_question_bank`, `/s{id}/regent` | Get all questions and options |
 
 ---
 

--- a/api/permissions.md
+++ b/api/permissions.md
@@ -86,10 +86,10 @@ Professors have **subject-specific access** based on group membership. They must
 | `/api/topics/{id}` | PUT | `/edit_topics`, `/regent` | Update topics |
 | `/api/topics/{id}` | DELETE | `/edit_topics`, `/regent` | Delete topics |
 | `/api/questions/` | POST | `/edit_questions`, `/regent` | Create questions |
-| `/api/questions/{id}` | GET | Any subject group | Get question |
+| `/api/questions/{id}` | GET | `/view_question_bank`, `/regent` | Get question |
 | `/api/questions/{id}` | PUT | `/edit_questions`, `/regent` | Update question |
 | `/api/questions/{id}` | DELETE | `/edit_questions`, `/regent` | Delete question |
-| `/api/questions/{id}/question-options` | GET | Any subject group | Get question options |
+| `/api/questions/{id}/question-options` | GET | `/view_question_bank`, `/regent` | Get question options |
 | `/api/question-options/` | POST | `/edit_questions`, `/regent` | Create options |
 | `/api/question-options/{id}` | PUT | `/edit_questions`, `/regent` | Update option |
 | `/api/question-options/{id}` | DELETE | `/edit_questions`, `/regent` | Delete option |
@@ -218,10 +218,10 @@ Same as professors with **all permission groups** directly evaluated via `verify
 |----------|--------|---------------------|-------------|
 | `/api/questions/` | POST | `/s{id}/edit_questions`, `/s{id}/regent` | Create questions |
 | `/api/questions/{subject_id}/XML` | POST | `/s{id}/edit_questions`, `/s{id}/regent` | Create questions from XML |
-| `/api/questions/{id}` | GET | Subject group member (`/s{id}`) | Get question by ID |
+| `/api/questions/{id}` | GET | `/s{id}/view_question_bank`, `/s{id}/regent` | Get question by ID |
 | `/api/questions/{id}` | PUT | `/s{id}/edit_questions`, `/s{id}/regent` | Update question |
 | `/api/questions/{id}` | DELETE | `/s{id}/edit_questions`, `/s{id}/regent` | Delete question |
-| `/api/questions/{id}/question-options` | GET | Subject group member (`/s{id}`) | Get question options |
+| `/api/questions/{id}/question-options` | GET | `/s{id}/view_question_bank`, `/s{id}/regent` | Get question options |
 
 ---
 

--- a/api/permissions.md
+++ b/api/permissions.md
@@ -1,0 +1,407 @@
+# Permissions & Access Control Documentation
+
+## Overview
+
+This document details the role-based access control (RBAC) system for the Education Platform API. Access is controlled through:
+
+1. **Realm Roles** - Global roles assigned to users in Keycloak
+2. **Subject Groups** - Per-subject groups with specific permissions
+
+---
+
+## Part 1: Roles and Their Permissions
+
+### User Roles
+
+| Role | Description | Scope |
+|------|-------------|-------|
+| `manager` | Platform administrators | Global - all subjects |
+| `professor` | Teaching staff | Subject-specific via groups |
+| `student` | Students | Subject-specific via groups |
+
+---
+
+### Manager Role
+
+**Realm Role:** `manager`
+
+Managers have **full access** to all endpoints and all subjects. They bypass group-based restrictions.
+
+#### Endpoints Accessible by Managers
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/api/users/me` | GET | Get own user info |
+| `/api/users/create` | POST | Create new users |
+| `/api/users/professors` | GET | List all professors |
+| `/api/users/students` | GET | List all students |
+| `/api/users/debug/token-info` | GET | Debug token information |
+| `/api/subjects/` | POST | Create new subjects |
+| `/api/subjects/` | GET | List all subjects |
+| `/api/subjects/{id}` | GET | Get any subject |
+| `/api/subjects/{id}` | PUT | Update any subject |
+| `/api/subjects/{id}` | DELETE | Delete any subject |
+| `/api/subjects/{id}/students` | GET | View enrolled students |
+| `/api/subjects/{id}/professors` | GET | View enrolled professors |
+| `/api/subjects/{id}/regent` | GET | View subject regent |
+| `/api/subjects/{id}/students` | POST | Add students to subject |
+| `/api/subjects/{id}/professors` | POST | Add professor to subject |
+| `/api/subjects/{id}/professors/{prof_id}` | PUT | Update professor permissions |
+| `/api/subjects/{id}/professors/{prof_id}` | DELETE | Remove professor from subject |
+| `/api/subjects/{id}/topics` | GET | Get all topics with question counts |
+| `/api/subjects/{id}/topics-list` | GET | Get topics list |
+| `/api/subjects/{id}/all-questions` | GET | Get all questions |
+| `/api/topics/` | POST | Create topics |
+| `/api/topics/{id}` | PUT | Update topics |
+| `/api/topics/{id}` | DELETE | Delete topics |
+| `/api/questions/` | POST | Create questions |
+| `/api/questions/{id}` | GET | Get question |
+| `/api/questions/{id}` | PUT | Update question |
+| `/api/questions/{id}` | DELETE | Delete question |
+| `/api/questions/{id}/question-options` | GET | Get question options |
+| `/api/question-options/` | POST | Create question options |
+| `/api/question-options/{id}` | PUT | Update option |
+| `/api/question-options/{id}` | DELETE | Delete option |
+| `/api/exams/generate` | POST | Generate exams |
+| `/api/exams/subject/{id}/configs` | GET | Get exam configs |
+
+---
+
+### Professor Role
+
+**Realm Role:** `professor`
+
+Professors have **subject-specific access** based on group membership. They must be explicitly added to subjects.
+
+#### Subject Groups for Professors
+
+| Group | Path | Permissions |
+|-------|------|-------------|
+| Professors (Base) | `/s{subject_id}/professors` | View students, view professors, view regent |
+| Edit Topics | `/s{subject_id}/edit_topics` | Create, update, delete topics |
+| Edit Questions | `/s{subject_id}/edit_questions` | Create, update, delete questions |
+| View Question Bank | `/s{subject_id}/view_question_bank` | View all questions in subject |
+| Add Students | `/s{subject_id}/add_students` | Add students to subject |
+| Generate Exams | `/s{subject_id}/generate_exams` | Generate exams |
+| View Grades | `/s{subject_id}/view_grades` | View student grades |
+| Auto Correct Exams | `/s{subject_id}/auto_correct_exams` | Auto-correct exams |
+
+#### Endpoints Accessible by Professors
+
+| Endpoint | Method | Required Group | Description |
+|----------|--------|----------------|-------------|
+| `/api/users/me` | GET | — | Get own user info |
+| `/api/users/professors` | GET | — | List all professors |
+| `/api/subjects/` | GET | Any subject group | List subjects user belongs to |
+| `/api/subjects/{id}` | GET | Any subject group | Get subject details |
+| `/api/subjects/{id}/students` | GET | `/professors`, `/regent` | View enrolled students |
+| `/api/subjects/{id}/professors` | GET | `/professors`, `/regent` | View enrolled professors |
+| `/api/subjects/{id}/regent` | GET | Any subject group | View subject regent |
+| `/api/subjects/{id}/students` | POST | `/add_students`, Manager, Regent | Add students |
+| `/api/subjects/{id}/professors` | POST | Manager, Regent | Add professor |
+| `/api/subjects/{id}/professors/{prof_id}` | PUT | Manager, Regent | Update professor permissions |
+| `/api/subjects/{id}/professors/{prof_id}` | DELETE | Manager, Regent | Remove professor |
+| `/api/subjects/{id}/topics` | GET | Any subject group | Get topics |
+| `/api/subjects/{id}/topics-list` | GET | Any subject group | Get topics list |
+| `/api/subjects/{id}/all-questions` | GET | Any subject group | Get all questions |
+| `/api/topics/` | POST | `/edit_topics`, Regent | Create topics |
+| `/api/topics/{id}` | PUT | `/edit_topics`, Regent | Update topics |
+| `/api/topics/{id}` | DELETE | `/edit_topics`, Regent | Delete topics |
+| `/api/questions/` | POST | `/edit_questions`, Regent | Create questions |
+| `/api/questions/{id}` | GET | Any subject group | Get question |
+| `/api/questions/{id}` | PUT | `/edit_questions`, Regent | Update question |
+| `/api/questions/{id}` | DELETE | `/edit_questions`, Regent | Delete question |
+| `/api/questions/{id}/question-options` | GET | Any subject group | Get question options |
+| `/api/question-options/` | POST | `/edit_questions`, Regent | Create options |
+| `/api/question-options/{id}` | PUT | `/edit_questions`, Regent | Update option |
+| `/api/question-options/{id}` | DELETE | `/edit_questions`, Regent | Delete option |
+| `/api/exams/generate` | POST | `/generate_exams` | Generate exams |
+| `/api/exams/subject/{id}/configs` | GET | Any subject group | Get exam configs |
+
+---
+
+### Student Role
+
+**Realm Role:** `student`
+
+Students have **read-only access** to subjects they are enrolled in.
+
+#### Subject Groups for Students
+
+| Group | Path | Permissions |
+|-------|------|-------------|
+| Students | `/s{subject_id}/student` | Basic student access |
+
+#### Endpoints Accessible by Students
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/api/users/me` | GET | Get own user info |
+| `/api/users/students` | GET | List all students |
+| `/api/subjects/` | GET | List enrolled subjects |
+| `/api/subjects/{id}` | GET | Get subject details |
+| `/api/subjects/{id}/topics` | GET | Get topics |
+| `/api/subjects/{id}/topics-list` | GET | Get topics list |
+| `/api/subjects/{id}/all-questions` | GET | View questions (if permitted) |
+| `/api/topics/` | GET | List all topics |
+| `/api/topics/{id}` | GET | Get topic details |
+| `/api/questions/{id}` | GET | Get question (view only) |
+| `/api/questions/{id}/question-options` | GET | View question options |
+| `/api/exams/subject/{id}/configs` | GET | View exam configs |
+
+---
+
+### Regent (Special Professor Role)
+
+**Not a realm role** - Regents are professors assigned to the `/s{subject_id}/regent` group for a specific subject.
+
+#### Regent Permissions
+
+Regents have **full management** over their assigned subject:
+
+| Permission | Description |
+|------------|-------------|
+| Create topics | Create new topics in subject |
+| Edit topics | Modify existing topics |
+| Delete topics | Remove topics |
+| Create questions | Add new questions |
+| Edit questions | Modify questions |
+| Delete questions | Remove questions |
+| Add students | Enroll students in subject |
+| Manage professors | Add/remove professors, set permissions |
+| View all | View students, professors, regent info |
+
+#### Endpoints Accessible by Regents
+
+Same as professors with **all permission groups** automatically granted for their subject.
+
+---
+
+## Part 2: Endpoints and Required Permissions
+
+### Health & Public Endpoints
+
+| Endpoint | Method | Access | Description |
+|----------|--------|--------|-------------|
+| `/health` | GET | Public | Health check |
+| `/` | GET | Public | API welcome message |
+| `/api/docs` | GET | Public | Swagger UI documentation |
+| `/redoc` | GET | Public | ReDoc documentation |
+
+---
+
+### User Endpoints (`/api/users/*`)
+
+| Endpoint | Method | Required Permission | Description |
+|----------|--------|---------------------|-------------|
+| `/api/users/me` | GET | Authenticated | Get current user info |
+| `/api/users/create` | POST | `manager` role | Create new user |
+| `/api/users/professors` | GET | Authenticated | List all professors |
+| `/api/users/students` | GET | Authenticated | List all students |
+| `/api/users/debug/token-info` | GET | `manager` role | Debug token information |
+
+---
+
+### Subject Endpoints (`/api/subjects/*`)
+
+| Endpoint | Method | Required Permission | Description |
+|----------|--------|---------------------|-------------|
+| `/api/subjects/` | POST | `manager` role | Create new subject |
+| `/api/subjects/` | GET | Authenticated | List accessible subjects |
+| `/api/subjects/{id}` | GET | Subject group member | Get subject by ID |
+| `/api/subjects/{id}` | PUT | `manager` role | Update subject |
+| `/api/subjects/{id}` | DELETE | `manager` role | Delete subject |
+| `/api/subjects/{id}/students` | GET | `manager`, `/regent`, `/professors` | View students |
+| `/api/subjects/{id}/professors` | GET | `manager`, `/regent`, `/professors` | View professors |
+| `/api/subjects/{id}/regent` | GET | Subject group member | View regent |
+| `/api/subjects/{id}/students` | POST | `manager`, `/regent`, `/add_students` | Add students |
+| `/api/subjects/{id}/professors` | POST | `manager`, `/regent` | Add professor |
+| `/api/subjects/{id}/professors/{prof_id}` | PUT | `manager`, `/regent` | Update professor permissions |
+| `/api/subjects/{id}/professors/{prof_id}` | DELETE | `manager`, `/regent` | Remove professor |
+| `/api/subjects/{id}/topics` | GET | Subject group member | Get topics with question counts |
+| `/api/subjects/{id}/topics-list` | GET | Subject group member | Get topics list |
+| `/api/subjects/{id}/all-questions` | GET | Subject group member | Get all questions and options |
+
+---
+
+### Topic Endpoints (`/api/topics/*`)
+
+| Endpoint | Method | Required Permission | Description |
+|----------|--------|---------------------|-------------|
+| `/api/topics/` | POST | `/edit_topics`, Regent | Create topic |
+| `/api/topics/` | GET | Authenticated | List all topics |
+| `/api/topics/{id}` | GET | Authenticated | Get topic by ID |
+| `/api/topics/{id}` | PUT | `/edit_topics`, Regent | Update topic |
+| `/api/topics/{id}` | DELETE | `/edit_topics`, Regent | Delete topic |
+
+---
+
+### Question Endpoints (`/api/questions/*`)
+
+| Endpoint | Method | Required Permission | Description |
+|----------|--------|---------------------|-------------|
+| `/api/questions/` | POST | `/edit_questions`, Regent | Create questions |
+| `/api/questions/{subject_id}/XML` | POST | `/edit_questions`, Regent | Create questions from XML |
+| `/api/questions/{id}` | GET | Authenticated | Get question by ID |
+| `/api/questions/{id}` | PUT | `/edit_questions`, Regent | Update question |
+| `/api/questions/{id}` | DELETE | `/edit_questions`, Regent | Delete question |
+| `/api/questions/{id}/question-options` | GET | Authenticated | Get question options |
+
+---
+
+### Question Option Endpoints (`/api/question-options/*`)
+
+| Endpoint | Method | Required Permission | Description |
+|----------|--------|---------------------|-------------|
+| `/api/question-options/` | POST | `/edit_questions`, Regent | Create question options |
+| `/api/question-options/{id}` | PUT | `/edit_questions`, Regent | Update option |
+| `/api/question-options/{id}` | DELETE | `/edit_questions`, Regent | Delete option |
+
+---
+
+### Exam Endpoints (`/api/exams/*`)
+
+| Endpoint | Method | Required Permission | Description |
+|----------|--------|---------------------|-------------|
+| `/api/exams/generate` | POST | `/generate_exams` | Generate exam PDFs |
+| `/api/exams/subject/{id}/configs` | GET | Subject group member | Get exam configurations |
+
+---
+
+## Group Hierarchy Structure
+
+```
+s{subject_id}/                    # Base subject group
+├── regent/                       # Subject regent (full control)
+├── students/                     # Enrolled students
+├── professors/                   # Base professors group
+├── edit_topics/                  # Can create/edit/delete topics
+├── edit_questions/               # Can create/edit/delete questions
+├── view_question_bank/           # Can view all questions
+├── add_students/                 # Can add students to subject
+├── generate_exams/               # Can generate exams
+├── view_grades/                  # Can view student grades
+└── auto_correct_exams/           # Can auto-correct exams
+```
+
+---
+
+## Permission Check Implementation
+
+### Role-Based Check
+
+```python
+from src.core.deps import require_manager
+
+@router.post("/", dependencies=[Depends(require_manager)])
+async def create_subject():
+    # Only managers can access
+```
+
+### Group-Based Check
+
+```python
+from src.core.deps import require_group
+
+@router.post("/students")
+async def add_students(
+    user: User = Depends(require_group("/s123/add_students"))
+):
+    # Only users in s123/add_students group can access
+```
+
+### Custom Permission Check
+
+```python
+from src.core.deps import get_current_user_info
+
+@router.get("/{subject_id}/students")
+async def get_students(
+    subject_id: int,
+    user_info: User = Depends(get_current_user_info)
+):
+    roles = user_info.realm_roles
+    groups = user_info.groups
+
+    if not ("manager" in roles or
+            any(g.endswith(f"s{subject_id}/regent") for g in groups) or
+            any(g.endswith(f"s{subject_id}/professors") for g in groups)):
+        raise HTTPException(status_code=403, detail="Access denied")
+```
+
+---
+
+## Authentication Flow
+
+1. **User logs in** via Keycloak (OIDC)
+2. **Keycloak returns JWT** with roles and groups
+3. **Frontend includes token** in `Authorization: Bearer <token>` header
+4. **API verifies token** using `get_current_user_info` dependency
+5. **Permission checks** validate roles/groups before executing endpoint
+
+---
+
+## Error Responses
+
+| Status Code | Meaning | Response |
+|-------------|---------|----------|
+| `401` | Not authenticated | `{"detail": "Not authenticated"}` |
+| `401` | Invalid token | `{"detail": "Invalid token"}` |
+| `403` | Missing role | `{"detail": "Requires {role} role"}` |
+| `403` | Missing group | `{"detail": "Requires membership in group {group}"}` |
+| `403` | Custom denial | `{"detail": "Access denied"}` |
+
+---
+
+## Summary Tables
+
+### Quick Reference: Who Can Access What
+
+| Action | Manager | Regent | Professor | Student |
+|--------|:-------:|:------:|:---------:|:-------:|
+| Create subjects | ✅ | ❌ | ❌ | ❌ |
+| Update/Delete any subject | ✅ | ❌ | ❌ | ❌ |
+| Create users | ✅ | ❌ | ❌ | ❌ |
+| Create topics (own subject) | ✅ | ✅ | ⚠️ | ❌ |
+| Create questions (own subject) | ✅ | ✅ | ⚠️ | ❌ |
+| Add students (own subject) | ✅ | ✅ | ⚠️ | ❌ |
+| Generate exams (own subject) | ✅ | ✅ | ⚠️ | ❌ |
+| View own subjects | ✅ | ✅ | ✅ | ✅ |
+| View questions | ✅ | ✅ | ✅ | ⚠️ |
+
+**Legend:**
+- ✅ = Full access
+- ⚠️ = Requires specific permission group
+- ❌ = No access
+
+---
+
+## Adding New Permissions
+
+To add a new permission group:
+
+1. **Add group to Keycloak** when creating subject:
+```python
+subgroups = [
+    "regent", "students", "professors",
+    "edit_topics", "edit_questions",
+    "view_question_bank", "add_students",
+    "generate_exams", "view_grades",
+    "auto_correct_exams",
+    "NEW_PERMISSION"  # Add here
+]
+```
+
+2. **Create dependency** in `src/core/deps.py`:
+```python
+def require_new_permission(subject_id: str):
+    group_name = f"/s{subject_id}/NEW_PERMISSION"
+    return require_group(group_name)
+```
+
+3. **Apply to endpoint**:
+```python
+@router.post("/new-feature", dependencies=[Depends(require_new_permission)])
+async def new_feature():
+    ...
+```

--- a/api/src/core/deps.py
+++ b/api/src/core/deps.py
@@ -91,6 +91,40 @@ def require_edit_question_bank(subject_id: str):
     group_name = f"/s{subject_id}/edit_question_bank"
     return require_group(group_name)
 
+def verify_permission(user_info: User, permission: str, allow_manager: bool = False) -> bool:
+    """
+    Verify if a user has a specific permission.
+    `permission` should be a group path like '/s1/regent', '/s1/add_students', or a role like 'manager'.
+    If `permission` is just a subject prefix like '/s1', it checks if the user is in ANY group for that subject.
+    If `allow_manager` is True, a user with the 'manager' realm role will always pass.
+    """
+    if allow_manager and "manager" in user_info.realm_roles:
+        return True
+        
+    if permission in user_info.realm_roles:
+        return True
+        
+    if permission in user_info.groups:
+        return True
+        
+    # Check if we are looking for ANY group in a subject (e.g., permission = "/s1")
+    if permission.startswith("/s") and len(permission.split("/")) == 2:
+        if any(g.startswith(permission + "/") for g in user_info.groups):
+            return True
+            
+    # Regent has all permissions for their subject
+    if permission.startswith("/s") and len(permission.split("/")) == 3:
+        subject_id_part = permission.split("/")[1] # e.g., s1
+        regent_group = f"/{subject_id_part}/regent"
+        if regent_group in user_info.groups:
+            return True
+            
+    logger.warning(f"User {user_info.username} denied access. Missing permission: {permission}")
+    raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail=f"Access denied."
+    )
+
 
 async def verify_regent_exists(regent_keycloak_id: str):
     """Dependency to check if the regent user exists in Keycloak before proceeding."""

--- a/api/src/core/deps.py
+++ b/api/src/core/deps.py
@@ -91,35 +91,31 @@ def require_edit_question_bank(subject_id: str):
     group_name = f"/s{subject_id}/edit_question_bank"
     return require_group(group_name)
 
-def verify_permission(user_info: User, permission: str, allow_manager: bool = False) -> bool:
+from typing import List
+
+def verify_permission(user_info: User, permissions: List[str], allow_manager: bool = False) -> bool:
     """
-    Verify if a user has a specific permission.
-    `permission` should be a group path like '/s1/regent', '/s1/add_students', or a role like 'manager'.
-    If `permission` is just a subject prefix like '/s1', it checks if the user is in ANY group for that subject.
+    Verify if a user has at least one of the specified permissions.
+    `permissions` should be a list of group paths like ['/s1/regent', '/s1/add_students'], or roles like ['manager'].
+    If a permission is just a subject prefix like '/s1', it checks if the user is in ANY group for that subject.
     If `allow_manager` is True, a user with the 'manager' realm role will always pass.
     """
     if allow_manager and "manager" in user_info.realm_roles:
         return True
         
-    if permission in user_info.realm_roles:
-        return True
-        
-    if permission in user_info.groups:
-        return True
-        
-    # Check if we are looking for ANY group in a subject (e.g., permission = "/s1")
-    if permission.startswith("/s") and len(permission.split("/")) == 2:
-        if any(g.startswith(permission + "/") for g in user_info.groups):
+    for permission in permissions:
+        if permission in user_info.realm_roles:
             return True
             
-    # Regent has all permissions for their subject
-    if permission.startswith("/s") and len(permission.split("/")) == 3:
-        subject_id_part = permission.split("/")[1] # e.g., s1
-        regent_group = f"/{subject_id_part}/regent"
-        if regent_group in user_info.groups:
+        if permission in user_info.groups:
             return True
             
-    logger.warning(f"User {user_info.username} denied access. Missing permission: {permission}")
+        # Check if we are looking for ANY group in a subject (e.g., permission = "/s1")
+        if permission.startswith("/s") and len(permission.split("/")) == 2:
+            if any(g.startswith(permission + "/") for g in user_info.groups):
+                return True
+            
+    logger.warning(f"User {user_info.username} denied access. Missing one of permissions: {permissions}")
     raise HTTPException(
         status_code=status.HTTP_403_FORBIDDEN,
         detail=f"Access denied."

--- a/api/src/routers/exam.py
+++ b/api/src/routers/exam.py
@@ -7,7 +7,7 @@ from src.core.db import get_session
 from src.models.user import User
 from src.models.exam_config import ExamConfigResponse
 from src.models.topic_config import TopicConfigDTO
-from src.core.deps import get_current_user_info
+from src.core.deps import get_current_user_info, verify_permission
 import logging
 import traceback
 
@@ -17,11 +17,13 @@ router = APIRouter()
 @router.get("/subject/{subject_id}/configs", response_model=List[ExamConfigResponse])
 async def get_subject_exam_configs(
     subject_id: int,
+    user_info: User = Depends(get_current_user_info),
     session: AsyncSession = Depends(get_session)
 ):
     """
     Get all exam configurations for a subject.
     """
+    verify_permission(user_info, f"/s{subject_id}")
     configs = await exam.get_exam_configs_by_subject(session, subject_id)
     
     response = []
@@ -52,13 +54,18 @@ async def get_subject_exam_configs(
 @router.post("/generate")
 async def generate_exams(
     exam_specs: dict,
-    session: AsyncSession = Depends(get_session),
-    #current_user: User = Depends(get_current_user_info)
+    user_info: User = Depends(get_current_user_info),
+    session: AsyncSession = Depends(get_session)
 ):
     """
     Generate exams based on specifications.
     Returns a ZIP file containing the generated exam PDFs.
     """
+    subject_id = exam_specs.get("subject_id")
+    if not subject_id:
+        raise HTTPException(status_code=400, detail="subject_id is required in exam_specs")
+        
+    verify_permission(user_info, f"/s{subject_id}/generate_exams")
     try:
         num_variations = exam_specs.get("num_variations", 1)
 

--- a/api/src/routers/exam.py
+++ b/api/src/routers/exam.py
@@ -23,7 +23,7 @@ async def get_subject_exam_configs(
     """
     Get all exam configurations for a subject.
     """
-    verify_permission(user_info, f"/s{subject_id}")
+    verify_permission(user_info, [f"/s{subject_id}"])
     configs = await exam.get_exam_configs_by_subject(session, subject_id)
     
     response = []
@@ -65,7 +65,7 @@ async def generate_exams(
     if not subject_id:
         raise HTTPException(status_code=400, detail="subject_id is required in exam_specs")
         
-    verify_permission(user_info, f"/s{subject_id}/generate_exams")
+    verify_permission(user_info, [f"/s{subject_id}/generate_exams", f"/s{subject_id}/regent"])
     try:
         num_variations = exam_specs.get("num_variations", 1)
 

--- a/api/src/routers/question.py
+++ b/api/src/routers/question.py
@@ -88,7 +88,7 @@ async def get_question(
         raise HTTPException(status_code=404, detail="Question not found")
         
     topic = await topic_service.get_topic_by_id(session, result.topic_id)
-    verify_permission(user_info, [f"/s{topic.subject_id}"])
+    verify_permission(user_info, [f"/s{topic.subject_id}/view_question_bank", f"/s{topic.subject_id}/regent"])
     
     return result
 
@@ -104,7 +104,7 @@ async def get_question_options(
         raise HTTPException(status_code=404, detail="Question not found")
         
     topic = await topic_service.get_topic_by_id(session, q_result.topic_id)
-    verify_permission(user_info, [f"/s{topic.subject_id}"])
+    verify_permission(user_info, [f"/s{topic.subject_id}/view_question_bank", f"/s{topic.subject_id}/regent"])
         
     result = await question.get_question_options_by_question_id(session,id)
 

--- a/api/src/routers/question.py
+++ b/api/src/routers/question.py
@@ -35,7 +35,7 @@ async def create_question(
             raise ValueError(f"Topic {first_topic_id} not found.")
             
         # Verify permission
-        verify_permission(user_info, f"/s{topic.subject_id}/edit_questions")
+        verify_permission(user_info, [f"/s{topic.subject_id}/edit_questions", f"/s{topic.subject_id}/regent"])
 
         # 2. Create the Question in the local database
         db_questions = await question.create_question(session,question_data)
@@ -69,7 +69,7 @@ async def create_question_from_XML(
     session: AsyncSession = Depends(get_session)
 ):
     "Create questions from XML file"
-    verify_permission(user_info, f"/s{subject_id}/edit_questions")
+    verify_permission(user_info, [f"/s{subject_id}/edit_questions", f"/s{subject_id}/regent"])
     result = await question.create_question_XML(session,subject_id,xml)
 
     return result
@@ -88,7 +88,7 @@ async def get_question(
         raise HTTPException(status_code=404, detail="Question not found")
         
     topic = await topic_service.get_topic_by_id(session, result.topic_id)
-    verify_permission(user_info, f"/s{topic.subject_id}")
+    verify_permission(user_info, [f"/s{topic.subject_id}"])
     
     return result
 
@@ -104,7 +104,7 @@ async def get_question_options(
         raise HTTPException(status_code=404, detail="Question not found")
         
     topic = await topic_service.get_topic_by_id(session, q_result.topic_id)
-    verify_permission(user_info, f"/s{topic.subject_id}")
+    verify_permission(user_info, [f"/s{topic.subject_id}"])
         
     result = await question.get_question_options_by_question_id(session,id)
 
@@ -127,7 +127,7 @@ async def put_question(
         raise HTTPException(status_code=404, detail="Question not found")
         
     topic = await topic_service.get_topic_by_id(session, q_result.topic_id)
-    verify_permission(user_info, f"/s{topic.subject_id}/edit_questions")
+    verify_permission(user_info, [f"/s{topic.subject_id}/edit_questions", f"/s{topic.subject_id}/regent"])
     try:
         result = await question.update_question(session, question_data)
         return result
@@ -151,7 +151,7 @@ async def delete_question(
         raise HTTPException(status_code=404, detail="Question not found")
         
     topic = await topic_service.get_topic_by_id(session, q_result.topic_id)
-    verify_permission(user_info, f"/s{topic.subject_id}/edit_questions")
+    verify_permission(user_info, [f"/s{topic.subject_id}/edit_questions", f"/s{topic.subject_id}/regent"])
     try:
         result = await question.delete_question(session, id)
         if result:

--- a/api/src/routers/question.py
+++ b/api/src/routers/question.py
@@ -3,8 +3,9 @@ from fastapi import APIRouter, Body, Depends, HTTPException, status
 from sqlmodel import select
 from src.models.question_option import QuestionOptionPublic
 from src.services import question
+from src.services import topic as topic_service
 from src.core.db import get_session
-from src.core.deps import get_current_user_info, require_subject_regent, verify_regent_exists
+from src.core.deps import get_current_user_info, verify_permission
 from src.models.question import Question, QuestionCreate, QuestionPublic, QuestionUpdate
 from src.models.user import User
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -13,24 +14,30 @@ import logging
 logger = logging.getLogger(__name__)
 router = APIRouter()
 
-@router.post("/", response_model=List[QuestionPublic])#, dependencies=[Depends(require_subject_regent)])
+@router.post("/", response_model=List[QuestionPublic])
 async def create_question(
     question_data: List[QuestionCreate],
-    #current_user: User = Depends(get_current_user_info), # This will be the regent's info due to verify_regent_exists
+    user_info: User = Depends(get_current_user_info),
     session: AsyncSession = Depends(get_session)
 ):
     """
     Create a new question (regent only).
-    Requires the 'regent' role.
+    Requires the 'edit_questions' group permission.
     """
-    #logger.info(f"Regent {current_user.user_id} is attempting to create a new question: {question_data.question_text}")
-
     try:
-        # 1. Verify current_user is regent BEFORE creating anything in the database
-        # Call the verification function explicitly here, now that we have current_user
-        #regent_info = await verify_regent_exists(current_user.user_id)
+        # Get the topic to know the subject
+        if not question_data:
+            raise ValueError("No questions provided.")
+            
+        first_topic_id = question_data[0].topic_id
+        topic = await topic_service.get_topic_by_id(session, first_topic_id)
+        if not topic:
+            raise ValueError(f"Topic {first_topic_id} not found.")
+            
+        # Verify permission
+        verify_permission(user_info, f"/s{topic.subject_id}/edit_questions")
 
-        # 2. Create the Topic in the local database
+        # 2. Create the Question in the local database
         db_questions = await question.create_question(session,question_data)
 
         question_ids = [q.id for q in db_questions]
@@ -54,14 +61,15 @@ async def create_question(
         )
     
 
-@router.post("/{subject_id}/XML", response_model=dict)#, dependencies=[Depends(require_subject_regent)])
+@router.post("/{subject_id}/XML", response_model=dict)
 async def create_question_from_XML(
     subject_id: int,
     xml: str = Body(required=True,media_type="application/xml"),
-    #current_user: User = Depends(get_current_user_info), # This will be the regent's info due to verify_regent_exists
+    user_info: User = Depends(get_current_user_info),
     session: AsyncSession = Depends(get_session)
 ):
     "Create questions from XML file"
+    verify_permission(user_info, f"/s{subject_id}/edit_questions")
     result = await question.create_question_XML(session,subject_id,xml)
 
     return result
@@ -70,6 +78,7 @@ async def create_question_from_XML(
 @router.get("/{id}", response_model=QuestionPublic)
 async def get_question(
     id: int,
+    user_info: User = Depends(get_current_user_info),
     session: AsyncSession = Depends(get_session)
 ):
     """Get question info from provided id"""
@@ -77,15 +86,26 @@ async def get_question(
 
     if not result:
         raise HTTPException(status_code=404, detail="Question not found")
+        
+    topic = await topic_service.get_topic_by_id(session, result.topic_id)
+    verify_permission(user_info, f"/s{topic.subject_id}")
     
     return result
 
 @router.get("/{id}/question-options", response_model=List[QuestionOptionPublic])
 async def get_question_options(
     id: int,
+    user_info: User = Depends(get_current_user_info),
     session: AsyncSession = Depends(get_session)
 ):
     """Get question options info from provided question id"""
+    q_result = await question.get_question_by_id(session,id)
+    if not q_result:
+        raise HTTPException(status_code=404, detail="Question not found")
+        
+    topic = await topic_service.get_topic_by_id(session, q_result.topic_id)
+    verify_permission(user_info, f"/s{topic.subject_id}")
+        
     result = await question.get_question_options_by_question_id(session,id)
 
     if not result:
@@ -98,9 +118,16 @@ async def get_question_options(
 async def put_question(
     id: int,
     question_data: QuestionUpdate,
+    user_info: User = Depends(get_current_user_info),
     session: AsyncSession = Depends(get_session),
 ):
     """Update question info from provided id"""
+    q_result = await question.get_question_by_id(session,id)
+    if not q_result:
+        raise HTTPException(status_code=404, detail="Question not found")
+        
+    topic = await topic_service.get_topic_by_id(session, q_result.topic_id)
+    verify_permission(user_info, f"/s{topic.subject_id}/edit_questions")
     try:
         result = await question.update_question(session, question_data)
         return result
@@ -115,9 +142,16 @@ async def put_question(
 @router.delete("/{id}", response_model=str)
 async def delete_question(
     id: int,
+    user_info: User = Depends(get_current_user_info),
     session: AsyncSession = Depends(get_session),
 ):
     """Delete question from provided id"""
+    q_result = await question.get_question_by_id(session,id)
+    if not q_result:
+        raise HTTPException(status_code=404, detail="Question not found")
+        
+    topic = await topic_service.get_topic_by_id(session, q_result.topic_id)
+    verify_permission(user_info, f"/s{topic.subject_id}/edit_questions")
     try:
         result = await question.delete_question(session, id)
         if result:

--- a/api/src/routers/question_option.py
+++ b/api/src/routers/question_option.py
@@ -1,9 +1,11 @@
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlmodel import select
 from src.services import question_option
+from src.services import question as question_service
+from src.services import topic as topic_service
 from src.models.question_option import QuestionOption, QuestionOptionCreate, QuestionOptionPublic, QuestionOptionUpdate
 from src.core.db import get_session
-from src.core.deps import get_current_user_info, require_subject_regent, verify_regent_exists
+from src.core.deps import get_current_user_info, verify_permission
 from src.models.user import User
 from sqlmodel.ext.asyncio.session import AsyncSession
 import logging
@@ -15,10 +17,25 @@ router = APIRouter()
 @router.post("/", response_model=List[QuestionOptionPublic])
 async def create_question_options(
     question_options_data: List[QuestionOptionCreate],
+    user_info: User = Depends(get_current_user_info),
     session: AsyncSession = Depends(get_session)
 ):
     """Create multiple question options"""
     try:
+        if not question_options_data:
+            raise ValueError("No question options provided.")
+            
+        first_question_id = question_options_data[0].question_id
+        q = await question_service.get_question_by_id(session, first_question_id)
+        if not q:
+            raise ValueError(f"Question {first_question_id} not found.")
+            
+        topic = await topic_service.get_topic_by_id(session, q.topic_id)
+        if not topic:
+            raise ValueError(f"Topic {q.topic_id} not found.")
+            
+        verify_permission(user_info, f"/s{topic.subject_id}/edit_questions")
+        
         db_options = await question_option.create_question_options(session, question_options_data)
         return db_options
     except ValueError as ve:
@@ -32,9 +49,18 @@ async def create_question_options(
 async def update_question_option(
     id: int,
     option_data: QuestionOptionUpdate,
+    user_info: User = Depends(get_current_user_info),
     session: AsyncSession = Depends(get_session)
 ):
     """Update a question option"""
+    existing_option = await session.get(QuestionOption, id)
+    if not existing_option:
+        raise HTTPException(status_code=404, detail="Question option not found")
+        
+    q = await question_service.get_question_by_id(session, existing_option.question_id)
+    topic = await topic_service.get_topic_by_id(session, q.topic_id)
+    verify_permission(user_info, f"/s{topic.subject_id}/edit_questions")
+    
     try:
         result = await question_option.update_question_option(session, id, option_data)
         if not result:
@@ -49,9 +75,17 @@ async def update_question_option(
 @router.delete("/{id}")
 async def delete_question_option(
     id: int,
+    user_info: User = Depends(get_current_user_info),
     session: AsyncSession = Depends(get_session)
 ):
     """Delete a question option"""
+    existing_option = await session.get(QuestionOption, id)
+    if not existing_option:
+        raise HTTPException(status_code=404, detail="Question option not found")
+        
+    q = await question_service.get_question_by_id(session, existing_option.question_id)
+    topic = await topic_service.get_topic_by_id(session, q.topic_id)
+    verify_permission(user_info, f"/s{topic.subject_id}/edit_questions")
     try:
         if await question_option.delete_question_option(session, id):
             return {"message": "Question option deleted successfully"}

--- a/api/src/routers/question_option.py
+++ b/api/src/routers/question_option.py
@@ -34,7 +34,7 @@ async def create_question_options(
         if not topic:
             raise ValueError(f"Topic {q.topic_id} not found.")
             
-        verify_permission(user_info, f"/s{topic.subject_id}/edit_questions")
+        verify_permission(user_info, [f"/s{topic.subject_id}/edit_questions", f"/s{topic.subject_id}/regent"])
         
         db_options = await question_option.create_question_options(session, question_options_data)
         return db_options
@@ -59,7 +59,7 @@ async def update_question_option(
         
     q = await question_service.get_question_by_id(session, existing_option.question_id)
     topic = await topic_service.get_topic_by_id(session, q.topic_id)
-    verify_permission(user_info, f"/s{topic.subject_id}/edit_questions")
+    verify_permission(user_info, [f"/s{topic.subject_id}/edit_questions", f"/s{topic.subject_id}/regent"])
     
     try:
         result = await question_option.update_question_option(session, id, option_data)
@@ -85,7 +85,7 @@ async def delete_question_option(
         
     q = await question_service.get_question_by_id(session, existing_option.question_id)
     topic = await topic_service.get_topic_by_id(session, q.topic_id)
-    verify_permission(user_info, f"/s{topic.subject_id}/edit_questions")
+    verify_permission(user_info, [f"/s{topic.subject_id}/edit_questions", f"/s{topic.subject_id}/regent"])
     try:
         if await question_option.delete_question_option(session, id):
             return {"message": "Question option deleted successfully"}

--- a/api/src/routers/subject.py
+++ b/api/src/routers/subject.py
@@ -160,7 +160,7 @@ async def get_subject_regent(
     session: AsyncSession = Depends(get_session)
 ):
     """View subject regent"""
-    verify_permission(user_info, [f"/s{subject_id}"])
+    verify_permission(user_info, [f"/s{subject_id}", f"/s{subject_id}/regent"], allow_manager=True)
     try:
         regent = await subject_service.get_regent_service(session, subject_id)
         return StudentInfo(

--- a/api/src/routers/subject.py
+++ b/api/src/routers/subject.py
@@ -270,7 +270,7 @@ async def get_all_topics_by_subject(
     session: AsyncSession = Depends(get_session)
 ):
     """Get all subject topics by subject ID."""
-    verify_permission(user_info, [f"/s{subject_id}"])
+    verify_permission(user_info, [f"/s{subject_id}/view_question_bank", f"/s{subject_id}/regent"])
     result = await subject_service.get_all_subject_topics(session, subject_id)
     if not result:
         raise HTTPException(status_code=404, detail="Topics not found")
@@ -284,7 +284,7 @@ async def get_all_by_subject(
     session: AsyncSession = Depends(get_session)
 ):
     """Get subject by ID."""
-    verify_permission(user_info, [f"/s{subject_id}"])
+    verify_permission(user_info, [f"/s{subject_id}/view_question_bank", f"/s{subject_id}/regent"])
     result = await subject_service.get_topics_questions_and_options_by_subject_id(session, subject_id)
     if not result:
         raise HTTPException(status_code=404, detail="Subject not found")
@@ -302,5 +302,5 @@ async def get_subject_topics_list(
     session: AsyncSession = Depends(get_session)
 ):
     """Get all topics from a given subject_id (Simple List)"""
-    verify_permission(user_info, [f"/s{subject_id}"])
+    verify_permission(user_info, [f"/s{subject_id}/view_question_bank", f"/s{subject_id}/regent"])
     return await subject_service.get_topics_from_subject(session, subject_id)

--- a/api/src/routers/subject.py
+++ b/api/src/routers/subject.py
@@ -3,7 +3,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from src.core.db import get_session
-from src.core.deps import require_manager, get_current_user_info
+from src.core.deps import require_manager, get_current_user_info, verify_permission
 from src.models.user import User 
 from src.models.subject import (
     SubjectCreateRequest, 
@@ -21,26 +21,6 @@ import logging
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
-
-# --- Helpers ---
-async def verify_manager_or_regent(subject_id: int, user_info: User):
-    """
-    Helper to enforce Manager or Regent access.
-    Uses dot notation for the Pydantic User object.
-    """
-    username = user_info.username
-    roles = user_info.realm_roles
-    groups = user_info.groups
-    
-    is_manager = "manager" in roles
-    is_regent = any(g.endswith(f"s{subject_id}/regent") for g in groups)
-    
-    if not (is_manager or is_regent):
-         logger.warning(f"User {username} denied access (Not Manager/Regent)")
-         raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Only Managers or the Subject Regent can perform this action."
-        )
 
 # --- Endpoints ---
 
@@ -135,14 +115,7 @@ async def get_subject_students(
     """
     View enrolled students.
     """
-    # Permission Check
-    roles = user_info.realm_roles
-    groups = user_info.groups
-    
-    if not ("manager" in roles or 
-            any(g.endswith(f"s{subject_id}/regent") for g in groups) or 
-            any(g.endswith(f"s{subject_id}/professors") for g in groups)):
-        raise HTTPException(status_code=403, detail="Access denied")
+    verify_permission(user_info, f"/s{subject_id}/professors", allow_manager=True)
     try:
         students = await subject_service.get_students_service(session, subject_id)
         # Map raw dictionary from Keycloak to Pydantic model
@@ -165,13 +138,7 @@ async def get_subject_professors(
     session: AsyncSession = Depends(get_session)
 ):
     """View professors in subject"""
-    roles = user_info.realm_roles
-    groups = user_info.groups
-    
-    if not ("manager" in roles or 
-            any(g.endswith(f"s{subject_id}/regent") for g in groups) or 
-            any(g.endswith(f"s{subject_id}/professors") for g in groups)):
-        raise HTTPException(status_code=403, detail="Access denied")
+    verify_permission(user_info, f"/s{subject_id}/professors", allow_manager=True)
     try:
         professors = await subject_service.get_professors_service(session, subject_id)
         return [
@@ -193,6 +160,7 @@ async def get_subject_regent(
     session: AsyncSession = Depends(get_session)
 ):
     """View subject regent"""
+    verify_permission(user_info, f"/s{subject_id}")
     try:
         regent = await subject_service.get_regent_service(session, subject_id)
         return StudentInfo(
@@ -215,14 +183,7 @@ async def add_students_to_subject(
     """
     Add students to a subject.
     """
-    # Permission Check
-    roles = user_info.realm_roles
-    groups = user_info.groups
-    
-    if not ("manager" in roles or 
-            any(g.endswith(f"s{subject_id}/regent") for g in groups) or 
-            any(g.endswith(f"s{subject_id}/add_students") for g in groups)):
-        raise HTTPException(status_code=403, detail="Access denied")
+    verify_permission(user_info, f"/s{subject_id}/add_students", allow_manager=True)
     try:
         await subject_service.add_students_service(session, subject_id, request.student_keycloak_ids)
         return {"message": "Students added successfully"}
@@ -241,7 +202,7 @@ async def add_professor_to_subject(
     """
     Add a professor with specific permissions.
     """
-    await verify_manager_or_regent(subject_id, user_info)
+    verify_permission(user_info, f"/s{subject_id}/regent", allow_manager=True)
     try:
         await subject_service.manage_professor_service(
             session, 
@@ -267,7 +228,7 @@ async def update_professor_permissions(
     """
     Update permissions for an existing professor.
     """
-    await verify_manager_or_regent(subject_id, user_info)
+    verify_permission(user_info, f"/s{subject_id}/regent", allow_manager=True)
     try:
         await subject_service.manage_professor_service(
             session, 
@@ -292,7 +253,7 @@ async def remove_professor_from_subject(
     """
     Remove a professor from all subject groups.
     """
-    await verify_manager_or_regent(subject_id, user_info)
+    verify_permission(user_info, f"/s{subject_id}/regent", allow_manager=True)
     try:
         await subject_service.remove_professor_service(session, subject_id, professor_id)
     except ValueError:
@@ -303,8 +264,13 @@ async def remove_professor_from_subject(
 # --- Existing Endpoints (Kept from current version) ---
 
 @router.get("/{subject_id}/topics", response_model=List[Tuple[TopicPublic, int]])
-async def get_all_topics_by_subject(subject_id: int, session: AsyncSession = Depends(get_session)):
+async def get_all_topics_by_subject(
+    subject_id: int, 
+    user_info: User = Depends(get_current_user_info),
+    session: AsyncSession = Depends(get_session)
+):
     """Get all subject topics by subject ID."""
+    verify_permission(user_info, f"/s{subject_id}")
     result = await subject_service.get_all_subject_topics(session, subject_id)
     if not result:
         raise HTTPException(status_code=404, detail="Topics not found")
@@ -312,8 +278,13 @@ async def get_all_topics_by_subject(subject_id: int, session: AsyncSession = Dep
 
 
 @router.get("/{subject_id}/all-questions", response_model=dict)
-async def get_all_by_subject(subject_id: int, session: AsyncSession = Depends(get_session)):
+async def get_all_by_subject(
+    subject_id: int, 
+    user_info: User = Depends(get_current_user_info),
+    session: AsyncSession = Depends(get_session)
+):
     """Get subject by ID."""
+    verify_permission(user_info, f"/s{subject_id}")
     result = await subject_service.get_topics_questions_and_options_by_subject_id(session, subject_id)
     if not result:
         raise HTTPException(status_code=404, detail="Subject not found")
@@ -325,6 +296,11 @@ async def get_all_by_subject(subject_id: int, session: AsyncSession = Depends(ge
 # The original file had both. I'll keep the one that matches the signature found in the previous read.
 
 @router.get("/{subject_id}/topics-list", response_model=List[TopicPublic])
-async def get_subject_topics_list(subject_id: int, session: AsyncSession = Depends(get_session)):
+async def get_subject_topics_list(
+    subject_id: int, 
+    user_info: User = Depends(get_current_user_info),
+    session: AsyncSession = Depends(get_session)
+):
     """Get all topics from a given subject_id (Simple List)"""
+    verify_permission(user_info, f"/s{subject_id}")
     return await subject_service.get_topics_from_subject(session, subject_id)

--- a/api/src/routers/subject.py
+++ b/api/src/routers/subject.py
@@ -115,7 +115,7 @@ async def get_subject_students(
     """
     View enrolled students.
     """
-    verify_permission(user_info, f"/s{subject_id}/professors", allow_manager=True)
+    verify_permission(user_info, [f"/s{subject_id}/professors", f"/s{subject_id}/regent"], allow_manager=True)
     try:
         students = await subject_service.get_students_service(session, subject_id)
         # Map raw dictionary from Keycloak to Pydantic model
@@ -138,7 +138,7 @@ async def get_subject_professors(
     session: AsyncSession = Depends(get_session)
 ):
     """View professors in subject"""
-    verify_permission(user_info, f"/s{subject_id}/professors", allow_manager=True)
+    verify_permission(user_info, [f"/s{subject_id}/professors", f"/s{subject_id}/regent"], allow_manager=True)
     try:
         professors = await subject_service.get_professors_service(session, subject_id)
         return [
@@ -160,7 +160,7 @@ async def get_subject_regent(
     session: AsyncSession = Depends(get_session)
 ):
     """View subject regent"""
-    verify_permission(user_info, f"/s{subject_id}")
+    verify_permission(user_info, [f"/s{subject_id}"])
     try:
         regent = await subject_service.get_regent_service(session, subject_id)
         return StudentInfo(
@@ -183,7 +183,7 @@ async def add_students_to_subject(
     """
     Add students to a subject.
     """
-    verify_permission(user_info, f"/s{subject_id}/add_students", allow_manager=True)
+    verify_permission(user_info, [f"/s{subject_id}/add_students", f"/s{subject_id}/regent"], allow_manager=True)
     try:
         await subject_service.add_students_service(session, subject_id, request.student_keycloak_ids)
         return {"message": "Students added successfully"}
@@ -202,7 +202,7 @@ async def add_professor_to_subject(
     """
     Add a professor with specific permissions.
     """
-    verify_permission(user_info, f"/s{subject_id}/regent", allow_manager=True)
+    verify_permission(user_info, [f"/s{subject_id}/regent"], allow_manager=True)
     try:
         await subject_service.manage_professor_service(
             session, 
@@ -228,7 +228,7 @@ async def update_professor_permissions(
     """
     Update permissions for an existing professor.
     """
-    verify_permission(user_info, f"/s{subject_id}/regent", allow_manager=True)
+    verify_permission(user_info, [f"/s{subject_id}/regent"], allow_manager=True)
     try:
         await subject_service.manage_professor_service(
             session, 
@@ -253,7 +253,7 @@ async def remove_professor_from_subject(
     """
     Remove a professor from all subject groups.
     """
-    verify_permission(user_info, f"/s{subject_id}/regent", allow_manager=True)
+    verify_permission(user_info, [f"/s{subject_id}/regent"], allow_manager=True)
     try:
         await subject_service.remove_professor_service(session, subject_id, professor_id)
     except ValueError:
@@ -270,7 +270,7 @@ async def get_all_topics_by_subject(
     session: AsyncSession = Depends(get_session)
 ):
     """Get all subject topics by subject ID."""
-    verify_permission(user_info, f"/s{subject_id}")
+    verify_permission(user_info, [f"/s{subject_id}"])
     result = await subject_service.get_all_subject_topics(session, subject_id)
     if not result:
         raise HTTPException(status_code=404, detail="Topics not found")
@@ -284,7 +284,7 @@ async def get_all_by_subject(
     session: AsyncSession = Depends(get_session)
 ):
     """Get subject by ID."""
-    verify_permission(user_info, f"/s{subject_id}")
+    verify_permission(user_info, [f"/s{subject_id}"])
     result = await subject_service.get_topics_questions_and_options_by_subject_id(session, subject_id)
     if not result:
         raise HTTPException(status_code=404, detail="Subject not found")
@@ -302,5 +302,5 @@ async def get_subject_topics_list(
     session: AsyncSession = Depends(get_session)
 ):
     """Get all topics from a given subject_id (Simple List)"""
-    verify_permission(user_info, f"/s{subject_id}")
+    verify_permission(user_info, [f"/s{subject_id}"])
     return await subject_service.get_topics_from_subject(session, subject_id)

--- a/api/src/routers/topic.py
+++ b/api/src/routers/topic.py
@@ -4,10 +4,9 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from src.services import topic
 from src.services import question
 from src.core.db import get_session
-from src.core.deps import require_subject_regent, verify_regent_exists
+from src.core.deps import get_current_user_info, verify_permission
 from src.models.topic import Topic, TopicCreate, TopicPublic, TopicUpdate
 from src.models.user import User
-from src.core.deps import get_current_user_info
 import logging
 from sqlmodel import select
 from typing import List
@@ -16,24 +15,18 @@ import src.services.topic as topic_service
 logger = logging.getLogger(__name__)
 router = APIRouter()
 
-@router.post("/", response_model=TopicPublic)#, dependencies=[Depends(require_subject_regent)])
+@router.post("/", response_model=TopicPublic)
 async def create_topic(
-    topic_data: TopicCreate, # Receive the request body data
+    topic_data: TopicCreate,
     session: AsyncSession = Depends(get_session),
-    #current_user: User = Depends(get_current_user_info)
+    user_info: User = Depends(get_current_user_info)
 ):
     """
     Create a new topic in the database.
-    Requires the 'regent' role.
+    Requires the 'edit_topics' group permission.
     """
-    #logger.info(f"User '{current_user.user_id}' is attempting to create topic '{topic_data.name}'")
-
+    verify_permission(user_info, f"/s{topic_data.subject_id}/edit_topics")
     try:
-        # 1. Verify current_user is regent BEFORE creating anything in the database
-        # Call the verification function explicitly here, now that we have current_user
-        #regent_info = await verify_regent_exists(current_user.user_id)
-
-        # 2. Create the Topic in the local database
         db_topic = await topic.create_topic(session,topic_data)
 
         logger.info(f"Topic '{db_topic.name}' created in database with ID: {db_topic.id}")
@@ -57,38 +50,48 @@ async def create_topic(
             detail="An error occurred while creating the topic in the database."
         )
 
-@router.get("/", response_model=List[TopicPublic])
-async def get_subjects(session: AsyncSession = Depends(get_session)):
-    """Get all topics."""
-    return await topic_service.get_all_topics(session)
-
 @router.get("/{id}", response_model=TopicPublic)
 async def read_topic(
     id: int,
-    session: AsyncSession = Depends(get_session)
+    session: AsyncSession = Depends(get_session),
+    user_info: User = Depends(get_current_user_info)
 ):
     """Get topic info from provided name"""
     result = await topic.get_topic_by_id(session,id)
     
     if not result:
         raise HTTPException(status_code=404, detail="Topic not found")
+        
+    verify_permission(user_info, f"/s{result.subject_id}")
     return TopicPublic.model_validate(result)
 
 @router.put("/{id}", response_model=TopicPublic)
 async def update_topic(
     id: int,
     topic_data: topic.TopicUpdate,
-    session: AsyncSession = Depends(get_session)
+    session: AsyncSession = Depends(get_session),
+    user_info: User = Depends(get_current_user_info)
 ):
     """Update topic"""
+    existing_topic = await topic.get_topic_by_id(session, id)
+    if not existing_topic:
+        raise HTTPException(status_code=404, detail="Topic not found")
+        
+    verify_permission(user_info, f"/s{existing_topic.subject_id}/edit_topics")
     return await topic.update_topic(session, topic_data, id)
 
 @router.delete("/{id}")
 async def delete_topic(
     id: int,
-    session: AsyncSession = Depends(get_session)
+    session: AsyncSession = Depends(get_session),
+    user_info: User = Depends(get_current_user_info)
 ):
     """Delete topic"""
+    existing_topic = await topic.get_topic_by_id(session, id)
+    if not existing_topic:
+        raise HTTPException(status_code=404, detail="Topic not found")
+        
+    verify_permission(user_info, f"/s{existing_topic.subject_id}/edit_topics")
     if await topic.delete_topic(session, id):
         return {"message": "Topic deleted successfully"}
     raise HTTPException(status_code=404, detail="Topic not found")

--- a/api/src/routers/topic.py
+++ b/api/src/routers/topic.py
@@ -25,7 +25,7 @@ async def create_topic(
     Create a new topic in the database.
     Requires the 'edit_topics' group permission.
     """
-    verify_permission(user_info, f"/s{topic_data.subject_id}/edit_topics")
+    verify_permission(user_info, [f"/s{topic_data.subject_id}/edit_topics", f"/s{topic_data.subject_id}/regent"])
     try:
         db_topic = await topic.create_topic(session,topic_data)
 
@@ -62,7 +62,7 @@ async def read_topic(
     if not result:
         raise HTTPException(status_code=404, detail="Topic not found")
         
-    verify_permission(user_info, f"/s{result.subject_id}")
+    verify_permission(user_info, [f"/s{result.subject_id}"])
     return TopicPublic.model_validate(result)
 
 @router.put("/{id}", response_model=TopicPublic)
@@ -77,7 +77,7 @@ async def update_topic(
     if not existing_topic:
         raise HTTPException(status_code=404, detail="Topic not found")
         
-    verify_permission(user_info, f"/s{existing_topic.subject_id}/edit_topics")
+    verify_permission(user_info, [f"/s{existing_topic.subject_id}/edit_topics", f"/s{existing_topic.subject_id}/regent"])
     return await topic.update_topic(session, topic_data, id)
 
 @router.delete("/{id}")
@@ -91,7 +91,7 @@ async def delete_topic(
     if not existing_topic:
         raise HTTPException(status_code=404, detail="Topic not found")
         
-    verify_permission(user_info, f"/s{existing_topic.subject_id}/edit_topics")
+    verify_permission(user_info, [f"/s{existing_topic.subject_id}/edit_topics", f"/s{existing_topic.subject_id}/regent"])
     if await topic.delete_topic(session, id):
         return {"message": "Topic deleted successfully"}
     raise HTTPException(status_code=404, detail="Topic not found")

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -75,7 +75,7 @@ def manager_user():
         username="manager",
         email="manager@example.com",
         realm_roles=["manager"],
-        groups=[]
+        groups=["/s1/regent", "/s99999/regent"]
     )
 
 @pytest.fixture

--- a/api/tests/unit/test_question.py
+++ b/api/tests/unit/test_question.py
@@ -40,7 +40,8 @@ async def test_create_questions(client, mock_auth, setup_topic):
     assert data[0]["question_text"] == "What is 2+2?"
 
 @pytest.mark.asyncio
-async def test_get_question_and_options(client, session, setup_topic):
+async def test_get_question_and_options(client, mock_auth, session, setup_topic):
+    app.dependency_overrides[get_current_user_info] = mock_auth
     topic = setup_topic
     from src.models.question import Question, QuestionCreate
     from src.services.question import create_question
@@ -88,9 +89,10 @@ async def test_create_question_invalid_topic(client, mock_auth):
     
     response = await client.post("/api/questions/", json=payload)
     # Should fail due to FK constraint
-    assert response.status_code in [400, 500]
+    assert response.status_code in [400, 403, 500]
 
 @pytest.mark.asyncio
-async def test_get_question_not_found(client):
+async def test_get_question_not_found(client, mock_auth):
+    app.dependency_overrides[get_current_user_info] = mock_auth
     response = await client.get("/api/questions/99999")
     assert response.status_code == 404

--- a/api/tests/unit/test_topic.py
+++ b/api/tests/unit/test_topic.py
@@ -24,34 +24,8 @@ async def test_create_topic(client, mock_auth, session):
     assert data["subject_id"] == subject.id
 
 @pytest.mark.asyncio
-async def test_get_topics(client, session):
-    # Public endpoint? Or auth required? Router says no dependency on get, but let's check.
-    # The router code shows `get_subjects` (which is actually get all topics) depends only on session.
-    
-    from src.models.subject import Subject
-    from src.models.topic import Topic
-    
-    sub = Subject(name="Math")
-    session.add(sub)
-    await session.commit()
-    await session.refresh(sub)
-    
-    t1 = Topic(name="Algebra", subject_id=sub.id)
-    t2 = Topic(name="Geometry", subject_id=sub.id)
-    session.add(t1)
-    session.add(t2)
-    await session.commit()
-    
-    response = await client.get("/api/topics/")
-    assert response.status_code == 200
-    data = response.json()
-    assert len(data) >= 2
-    names = [t["name"] for t in data]
-    assert "Algebra" in names
-    assert "Geometry" in names
-
-@pytest.mark.asyncio
-async def test_get_topic_by_id(client, session):
+async def test_get_topic_by_id(client, session, mock_auth):
+    app.dependency_overrides[get_current_user_info] = mock_auth
     from src.models.subject import Subject
     from src.models.topic import Topic
     
@@ -84,9 +58,10 @@ async def test_create_topic_invalid_subject(client, mock_auth, session):
     # If not handled explicitly, it's usually 500. 
     # Let's see if we can catch integrity errors. 
     # Current implementation might just let it fail.
-    assert response.status_code in [400, 500] 
+    assert response.status_code in [400, 403, 500] 
 
 @pytest.mark.asyncio
-async def test_get_topic_not_found(client, session):
+async def test_get_topic_not_found(client, session, mock_auth):
+    app.dependency_overrides[get_current_user_info] = mock_auth
     response = await client.get("/api/topics/99999")
     assert response.status_code == 404

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -6,6 +6,15 @@ GREEN='\033[0;32m'
 RED='\033[0;31m'
 NC='\033[0m' # No Color
 
+START_DIR=$(pwd)
+
+function cleanup {
+    echo -e "${GREEN}Cleaning up test infrastructure...${NC}"
+    cd "$START_DIR"
+    docker compose -p edupro-test -f deployment/docker-compose.test.yml down -v
+}
+trap cleanup EXIT
+
 echo -e "${GREEN}Starting Test Suite Setup...${NC}"
 
 # 1. Start Infrastructure

--- a/web/src/routeTree.gen.ts
+++ b/web/src/routeTree.gen.ts
@@ -129,7 +129,7 @@ declare module '@tanstack/react-router' {
     '/_layout': {
       id: '/_layout'
       path: ''
-      fullPath: '/'
+      fullPath: ''
       preLoaderRoute: typeof LayoutRouteImport
       parentRoute: typeof rootRouteImport
     }

--- a/web/src/routeTree.gen.ts
+++ b/web/src/routeTree.gen.ts
@@ -129,7 +129,7 @@ declare module '@tanstack/react-router' {
     '/_layout': {
       id: '/_layout'
       path: ''
-      fullPath: ''
+      fullPath: '/'
       preLoaderRoute: typeof LayoutRouteImport
       parentRoute: typeof rootRouteImport
     }


### PR DESCRIPTION
# Description

This PR introduces a significant refactor and tightening of the API's Role-Based Access Control (RBAC) system, alongside updates to documentation and testing infrastructure.

**Key Changes:**
* **Centralized Permission Checking:** Implemented a new, generic `verify_permission` method in `deps.py`. It now accepts a list of required permissions, making endpoint security declarations much cleaner and more explicit (e.g., passing the regent permission directly in the required list).
* **Narrowed Manager Access:** Fixed a security oversight where Managers had implicit, unconstrained access to subject contents. Managers can now only perform administrative tasks (CRUD on subjects, users, enrollments) and can no longer bypass group restrictions to view/edit topics, questions, or exams unless explicitly added to those subject groups.
* **Secured Question Bank:** Locked down several endpoints (`/topics`, `/topics-list`, `/all-questions`, `/questions/{id}`, and `/questions/{id}/question-options`). Previously, anyone with access to the subject could view them. Now, **only** the Regent or a Professor with the `/view_question_bank` group permission can access the question bank. Students and standard professors are correctly restricted.
* **Documentation Updates:** Thoroughly created a permission document, `api/permissions.md`, and test documentation, `TEST.md`, to accurately reflect the current permissions and test infrastructure.
* **Test Infrastructure:** Added an `EXIT` trap to `run_tests.sh` to ensure the isolated Docker test infrastructure is properly cleaned up (`docker compose down -v`) upon script termination, regardless of whether the tests passed or failed.

Fixes # (issue) <!-- Add issue number here if applicable -->

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue) <!-- Security fix preventing unauthorized question bank access -->
- [x] New feature (non-breaking change which adds functionality) <!-- Generic verify_permission check, test script cleanup -->
- [x] This change requires a documentation update

# How Has This Been Tested?

The new permission logic was validated locally using the updated test suite, ensuring that users without the exact Keycloak groups receive `403 Forbidden` responses.

- [x] **API Unit Tests:** Verified that endpoints correctly evaluate the new list-based `verify_permission` dependency. Handled mock users for Managers and standard users to guarantee proper authorization rejections.
- [x] **Test Script Execution:** Ran `run_tests.sh` locally to confirm that the new cleanup trap successfully shuts down the test database and Keycloak containers upon completion.

**Test Configuration**:
* Firmware version: N/A
* Hardware: N/A
* Toolchain: Python/uv, Pytest, Docker Compose
* SDK: FastAPI, Keycloak Admin

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules