### PR TITLE
Endpoit for my waiting rooms

### DIFF
--- a/api/src/models/waiting_room.py
+++ b/api/src/models/waiting_room.py
@@ -41,3 +41,14 @@ class WaitingRoomInfoResponse(BaseModel):
 class WaitingRoomMetricsResponse(BaseModel):
     associated_exams_count: int
     associated_students_count: int
+
+
+class ProfessorWaitingRoomInfo(BaseModel):
+    """Information about a single waiting room for a professor."""
+    state: str
+    role: str
+
+
+class ProfessorWaitingRoomsResponse(BaseModel):
+    """Response model for professor's waiting rooms grouped by subject."""
+    waiting_rooms: dict[str, dict[str, ProfessorWaitingRoomInfo]]

--- a/api/src/models/waiting_room.py
+++ b/api/src/models/waiting_room.py
@@ -43,12 +43,15 @@ class WaitingRoomMetricsResponse(BaseModel):
     associated_students_count: int
 
 
-class ProfessorWaitingRoomInfo(BaseModel):
+class ProfessorWaitingRoomItem(BaseModel):
     """Information about a single waiting room for a professor."""
+    subject_id: int
+    subject_name: str
+    waiting_room_id: int
     state: str
     role: str
 
 
 class ProfessorWaitingRoomsResponse(BaseModel):
-    """Response model for professor's waiting rooms grouped by subject."""
-    waiting_rooms: dict[str, dict[str, ProfessorWaitingRoomInfo]]
+    """Response model for professor's waiting rooms as a flat list."""
+    waiting_rooms: list[ProfessorWaitingRoomItem]

--- a/api/src/routers/waiting_room.py
+++ b/api/src/routers/waiting_room.py
@@ -218,16 +218,17 @@ async def get_professor_waiting_rooms(
     """
     Get all waiting rooms where the professor is either a regent or vigilant.
     
-    Returns a nested structure grouped by subject_id:
+    Returns a flat list of waiting rooms with subject information:
     {
-        "waiting_rooms": {
-            "subject_id": {
-                "waiting_room_id": {
-                    "state": "preparation" | "running" | "closed",
-                    "role": "regent" | "vigilant"
-                }
+        "waiting_rooms": [
+            {
+                "subject_id": 1,
+                "subject_name": "Mathematics",
+                "waiting_room_id": 5,
+                "state": "preparation" | "running" | "closed",
+                "role": "regent" | "vigilant"
             }
-        }
+        ]
     }
     
     Only accessible by users with the professor role.

--- a/api/src/routers/waiting_room.py
+++ b/api/src/routers/waiting_room.py
@@ -4,7 +4,7 @@ from sqlmodel import select
 from src.core.db import get_session
 from src.models.user import User
 from src.models.exam_config import ExamConfig
-from src.models.waiting_room import WaitingRoom, WaitingRoomCreateRequest, WaitingRoomResponse, WaitingRoomState, WaitingRoomInfoResponse, WaitingRoomMetricsResponse
+from src.models.waiting_room import WaitingRoom, WaitingRoomCreateRequest, WaitingRoomResponse, WaitingRoomState, WaitingRoomInfoResponse, WaitingRoomMetricsResponse, ProfessorWaitingRoomsResponse
 import src.services.waiting_room as waiting_room_service
 from src.core.deps import get_current_user_info, verify_permission
 from src.core.keycloak import keycloak_client
@@ -208,6 +208,51 @@ async def get_waiting_room_metrics(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Failed to retrieve waiting room metrics: {str(e)}"
         )
+
+
+@router.get("/professor/my-waiting-rooms", response_model=ProfessorWaitingRoomsResponse)
+async def get_professor_waiting_rooms(
+    user_info: User = Depends(get_current_user_info),
+    session: AsyncSession = Depends(get_session)
+):
+    """
+    Get all waiting rooms where the professor is either a regent or vigilant.
+    
+    Returns a nested structure grouped by subject_id:
+    {
+        "waiting_rooms": {
+            "subject_id": {
+                "waiting_room_id": {
+                    "state": "preparation" | "running" | "closed",
+                    "role": "regent" | "vigilant"
+                }
+            }
+        }
+    }
+    
+    Only accessible by users with the professor role.
+    """
+    # Verify professor role
+    if "professor" not in user_info.realm_roles:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="This endpoint requires the professor role."
+        )
+
+    try:
+        waiting_rooms = await waiting_room_service.get_professor_waiting_rooms(
+            session=session,
+            professor_keycloak_id=user_info.user_id,
+            professor_groups=user_info.groups
+        )
+        return {"waiting_rooms": waiting_rooms}
+    except Exception as e:
+        logger.error(f"Failed to retrieve professor waiting rooms: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to retrieve waiting rooms: {str(e)}"
+        )
+
 
 @router.patch("/{waiting_room_id}/close", response_model=WaitingRoomResponse)
 async def close_waiting_room(

--- a/api/src/services/waiting_room.py
+++ b/api/src/services/waiting_room.py
@@ -1,9 +1,10 @@
 from sqlmodel.ext.asyncio.session import AsyncSession
 from sqlmodel import select
-from src.models.waiting_room import WaitingRoom, WaitingRoomState, WaitingRoomInfoResponse, WaitingRoomMetricsResponse
+from src.models.waiting_room import WaitingRoom, WaitingRoomState, WaitingRoomInfoResponse, WaitingRoomMetricsResponse, ProfessorWaitingRoomItem
 from src.models.warning import Warning, WarningType
 from src.models.exam_config import ExamConfig
 from src.models.exam import Exam
+from src.models.subject import Subject
 from src.services.exam import get_exams_by_config_id
 from src.core.keycloak import keycloak_client
 from typing import Optional, List, Set, Dict
@@ -240,27 +241,25 @@ async def get_professor_waiting_rooms(
     session: AsyncSession,
     professor_keycloak_id: str,
     professor_groups: List[str]
-) -> Dict[str, Dict[str, Dict[str, str]]]:
+) -> List[ProfessorWaitingRoomItem]:
     """
     Get all waiting rooms where the professor is either a regent or vigilant.
     
     Uses the professor's Keycloak groups to find associated waiting rooms.
     Groups follow the pattern: w{waiting_room_id}/regent or w{waiting_room_id}/vigilant
     
-    Returns a nested dict structure:
-    {
-        subject_id: {
-            waiting_room_id: {
-                "state": "preparation" | "running" | "closed",
-                "role": "regent" | "vigilant"
-            },
-            ...
+    Returns a flat list of waiting rooms with subject information:
+    [
+        {
+            "subject_id": 1,
+            "subject_name": "Mathematics",
+            "waiting_room_id": 5,
+            "state": "preparation" | "running" | "closed",
+            "role": "regent" | "vigilant"
         },
         ...
-    }
+    ]
     """
-    result: Dict[str, Dict[str, Dict[str, str]]] = {}
-    
     # Extract waiting room IDs and roles from groups
     waiting_room_ids_with_roles: Dict[int, str] = {}
     
@@ -279,7 +278,7 @@ async def get_professor_waiting_rooms(
                         continue
     
     if not waiting_room_ids_with_roles:
-        return result
+        return []
     
     # Fetch all waiting rooms at once
     stmt = select(WaitingRoom).where(
@@ -288,7 +287,9 @@ async def get_professor_waiting_rooms(
     results = await session.exec(stmt)
     waiting_rooms = results.all()
     
-    # For each waiting room, get the subject_id via ExamConfig
+    result: List[ProfessorWaitingRoomItem] = []
+    
+    # For each waiting room, get the subject info via ExamConfig
     for wr in waiting_rooms:
         role = waiting_room_ids_with_roles.get(wr.id)
         if not role:
@@ -300,16 +301,18 @@ async def get_professor_waiting_rooms(
             logger.warning(f"ExamConfig not found for waiting room {wr.id}")
             continue
         
-        subject_id = str(exam_config.subject_id)
+        # Get Subject to get the name
+        subject = await session.get(Subject, exam_config.subject_id)
+        if not subject:
+            logger.warning(f"Subject not found for exam config {wr.exam_config_id}")
+            continue
         
-        # Initialize subject entry if needed
-        if subject_id not in result:
-            result[subject_id] = {}
-        
-        # Add waiting room info
-        result[subject_id][str(wr.id)] = {
-            "state": wr.state.value,
-            "role": role
-        }
+        result.append(ProfessorWaitingRoomItem(
+            subject_id=subject.id,
+            subject_name=subject.name,
+            waiting_room_id=wr.id,
+            state=wr.state.value,
+            role=role
+        ))
     
     return result

--- a/api/src/services/waiting_room.py
+++ b/api/src/services/waiting_room.py
@@ -8,6 +8,9 @@ from src.services.exam import get_exams_by_config_id
 from src.core.keycloak import keycloak_client
 from typing import Optional, List, Set, Dict
 import json
+import logging
+
+logger = logging.getLogger(__name__)
 
 async def get_waiting_room(session: AsyncSession, waiting_room_id: int) -> Optional[WaitingRoom]:
     stmt = select(WaitingRoom).where(WaitingRoom.id == waiting_room_id)
@@ -231,3 +234,82 @@ async def close_waiting_room_service(session: AsyncSession, waiting_room_id: int
     await session.refresh(waiting_room)
 
     return waiting_room
+
+
+async def get_professor_waiting_rooms(
+    session: AsyncSession,
+    professor_keycloak_id: str,
+    professor_groups: List[str]
+) -> Dict[str, Dict[str, Dict[str, str]]]:
+    """
+    Get all waiting rooms where the professor is either a regent or vigilant.
+    
+    Uses the professor's Keycloak groups to find associated waiting rooms.
+    Groups follow the pattern: w{waiting_room_id}/regent or w{waiting_room_id}/vigilant
+    
+    Returns a nested dict structure:
+    {
+        subject_id: {
+            waiting_room_id: {
+                "state": "preparation" | "running" | "closed",
+                "role": "regent" | "vigilant"
+            },
+            ...
+        },
+        ...
+    }
+    """
+    result: Dict[str, Dict[str, Dict[str, str]]] = {}
+    
+    # Extract waiting room IDs and roles from groups
+    waiting_room_ids_with_roles: Dict[int, str] = {}
+    
+    for group in professor_groups:
+        # Check for waiting room groups (pattern: w{id}/role)
+        if group.startswith("w") and "/" in group:
+            parts = group.split("/", 1)
+            if len(parts) == 2:
+                wr_prefix, role = parts
+                if role in ["regent", "vigilant"]:
+                    try:
+                        waiting_room_id = int(wr_prefix[1:])  # Remove 'w' prefix
+                        waiting_room_ids_with_roles[waiting_room_id] = role
+                    except ValueError:
+                        logger.warning(f"Invalid waiting room ID in group: {group}")
+                        continue
+    
+    if not waiting_room_ids_with_roles:
+        return result
+    
+    # Fetch all waiting rooms at once
+    stmt = select(WaitingRoom).where(
+        WaitingRoom.id.in_(list(waiting_room_ids_with_roles.keys()))
+    )
+    results = await session.exec(stmt)
+    waiting_rooms = results.all()
+    
+    # For each waiting room, get the subject_id via ExamConfig
+    for wr in waiting_rooms:
+        role = waiting_room_ids_with_roles.get(wr.id)
+        if not role:
+            continue
+        
+        # Get ExamConfig to find subject_id
+        exam_config = await session.get(ExamConfig, wr.exam_config_id)
+        if not exam_config:
+            logger.warning(f"ExamConfig not found for waiting room {wr.id}")
+            continue
+        
+        subject_id = str(exam_config.subject_id)
+        
+        # Initialize subject entry if needed
+        if subject_id not in result:
+            result[subject_id] = {}
+        
+        # Add waiting room info
+        result[subject_id][str(wr.id)] = {
+            "state": wr.state.value,
+            "role": role
+        }
+    
+    return result

--- a/api/tests/unit/test_professor_waiting_rooms.py
+++ b/api/tests/unit/test_professor_waiting_rooms.py
@@ -1,0 +1,335 @@
+import pytest
+from src.core.deps import get_current_user_info
+from src.main import app
+from src.models.user import User
+from src.models.waiting_room import WaitingRoom, WaitingRoomState
+from src.models.subject import Subject
+from src.models.exam_config import ExamConfig
+
+
+@pytest.fixture
+def professor_user():
+    """Create a mock professor user with waiting room groups."""
+    return User(
+        user_id="prof-123",
+        username="test_professor",
+        email="prof@example.com",
+        realm_roles=["professor"],
+        groups=[
+            "/s1/regent",
+            "w1/regent",
+            "w2/vigilant",
+            "w3/regent"
+        ]
+    )
+
+
+@pytest.fixture
+def professor_user_no_waiting_rooms():
+    """Create a mock professor with no waiting room groups."""
+    return User(
+        user_id="prof-456",
+        username="test_professor_2",
+        email="prof2@example.com",
+        realm_roles=["professor"],
+        groups=["/s1/regent", "/s1/professors"]
+    )
+
+
+@pytest.fixture
+def student_user():
+    """Create a mock student user (should be denied access)."""
+    return User(
+        user_id="student-789",
+        username="test_student",
+        email="student@example.com",
+        realm_roles=["student"],
+        groups=["/s1/student"]
+    )
+
+
+@pytest.fixture
+async def setup_waiting_rooms(session):
+    """Create subjects, exam configs, and waiting rooms for testing."""
+    # Create subjects
+    subject1 = Subject(name="Subject 1")
+    subject2 = Subject(name="Subject 2")
+    session.add(subject1)
+    session.add(subject2)
+    await session.commit()
+    await session.refresh(subject1)
+    await session.refresh(subject2)
+
+    # Create exam configs
+    exam_config1 = ExamConfig(subject_id=subject1.id, fraction=0)
+    exam_config2 = ExamConfig(subject_id=subject1.id, fraction=1)
+    exam_config3 = ExamConfig(subject_id=subject2.id, fraction=0)
+    session.add(exam_config1)
+    session.add(exam_config2)
+    session.add(exam_config3)
+    await session.commit()
+    await session.refresh(exam_config1)
+    await session.refresh(exam_config2)
+    await session.refresh(exam_config3)
+
+    # Create waiting rooms with different states
+    wr1 = WaitingRoom(exam_config_id=exam_config1.id, state=WaitingRoomState.PREPARATION)
+    wr2 = WaitingRoom(exam_config_id=exam_config2.id, state=WaitingRoomState.RUNNING)
+    wr3 = WaitingRoom(exam_config_id=exam_config3.id, state=WaitingRoomState.CLOSED)
+    session.add(wr1)
+    session.add(wr2)
+    session.add(wr3)
+    await session.commit()
+    await session.refresh(wr1)
+    await session.refresh(wr2)
+    await session.refresh(wr3)
+
+    return {
+        "subject1_id": subject1.id,
+        "subject2_id": subject2.id,
+        "wr1_id": wr1.id,
+        "wr2_id": wr2.id,
+        "wr3_id": wr3.id
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_professor_waiting_rooms_success(client, professor_user, setup_waiting_rooms, session):
+    """Test professor can retrieve their waiting rooms grouped by subject."""
+    app.dependency_overrides[get_current_user_info] = lambda: professor_user
+    
+    response = await client.get("/api/waiting-rooms/professor/my-waiting-rooms")
+    
+    assert response.status_code == 200
+    data = response.json()
+    
+    assert "waiting_rooms" in data
+    waiting_rooms = data["waiting_rooms"]
+    
+    # Should have entries for both subjects
+    assert str(setup_waiting_rooms["subject1_id"]) in waiting_rooms
+    assert str(setup_waiting_rooms["subject2_id"]) in waiting_rooms
+    
+    # Subject 1 should have 2 waiting rooms (wr1 and wr2)
+    subject1_rooms = waiting_rooms[str(setup_waiting_rooms["subject1_id"])]
+    assert str(setup_waiting_rooms["wr1_id"]) in subject1_rooms
+    assert str(setup_waiting_rooms["wr2_id"]) in subject1_rooms
+    
+    # Check wr1 (regent, preparation)
+    wr1_data = subject1_rooms[str(setup_waiting_rooms["wr1_id"])]
+    assert wr1_data["state"] == "preparation"
+    assert wr1_data["role"] == "regent"
+    
+    # Check wr2 (vigilant, running)
+    wr2_data = subject1_rooms[str(setup_waiting_rooms["wr2_id"])]
+    assert wr2_data["state"] == "running"
+    assert wr2_data["role"] == "vigilant"
+    
+    # Subject 2 should have 1 waiting room (wr3)
+    subject2_rooms = waiting_rooms[str(setup_waiting_rooms["subject2_id"])]
+    assert str(setup_waiting_rooms["wr3_id"]) in subject2_rooms
+    
+    # Check wr3 (regent, closed)
+    wr3_data = subject2_rooms[str(setup_waiting_rooms["wr3_id"])]
+    assert wr3_data["state"] == "closed"
+    assert wr3_data["role"] == "regent"
+
+
+@pytest.mark.asyncio
+async def test_get_professor_waiting_rooms_empty(client, professor_user_no_waiting_rooms, session):
+    """Test professor with no waiting room groups gets empty response."""
+    app.dependency_overrides[get_current_user_info] = lambda: professor_user_no_waiting_rooms
+    
+    response = await client.get("/api/waiting-rooms/professor/my-waiting-rooms")
+    
+    assert response.status_code == 200
+    data = response.json()
+    
+    assert "waiting_rooms" in data
+    assert data["waiting_rooms"] == {}
+
+
+@pytest.mark.asyncio
+async def test_get_professor_waiting_rooms_denied_for_student(client, student_user, session):
+    """Test that students cannot access the professor waiting rooms endpoint."""
+    app.dependency_overrides[get_current_user_info] = lambda: student_user
+    
+    response = await client.get("/api/waiting-rooms/professor/my-waiting-rooms")
+    
+    assert response.status_code == 403
+    assert "professor role" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_get_professor_waiting_rooms_partial_groups(client, session):
+    """Test professor with only some waiting room groups."""
+    partial_prof = User(
+        user_id="prof-partial",
+        username="partial_prof",
+        email="partial@example.com",
+        realm_roles=["professor"],
+        groups=["w1/regent"]  # Only one waiting room group
+    )
+    
+    # Create only one waiting room
+    subject = Subject(name="Test Subject")
+    session.add(subject)
+    await session.commit()
+    await session.refresh(subject)
+    
+    exam_config = ExamConfig(subject_id=subject.id, fraction=0)
+    session.add(exam_config)
+    await session.commit()
+    await session.refresh(exam_config)
+    
+    wr = WaitingRoom(exam_config_id=exam_config.id, state=WaitingRoomState.RUNNING)
+    session.add(wr)
+    await session.commit()
+    await session.refresh(wr)
+    
+    app.dependency_overrides[get_current_user_info] = lambda: partial_prof
+    
+    response = await client.get("/api/waiting-rooms/professor/my-waiting-rooms")
+    
+    assert response.status_code == 200
+    data = response.json()
+    
+    assert "waiting_rooms" in data
+    waiting_rooms = data["waiting_rooms"]
+    
+    # Should have only one subject
+    assert len(waiting_rooms) == 1
+    assert str(subject.id) in waiting_rooms
+    
+    # Should have only one waiting room
+    assert len(waiting_rooms[str(subject.id)]) == 1
+    assert str(wr.id) in waiting_rooms[str(subject.id)]
+    
+    wr_data = waiting_rooms[str(subject.id)][str(wr.id)]
+    assert wr_data["state"] == "running"
+    assert wr_data["role"] == "regent"
+
+
+@pytest.mark.asyncio
+async def test_get_professor_waiting_rooms_invalid_group_format(client, session):
+    """Test that invalid group formats are gracefully ignored."""
+    prof_with_invalid_groups = User(
+        user_id="prof-invalid",
+        username="invalid_prof",
+        email="invalid@example.com",
+        realm_roles=["professor"],
+        groups=[
+            "w1/regent",      # Valid
+            "waiting/123",    # Invalid format
+            "wabc/regent",    # Invalid ID
+            "w999/vigilant"   # Valid but WR doesn't exist
+        ]
+    )
+    
+    # Create one waiting room
+    subject = Subject(name="Test Subject")
+    session.add(subject)
+    await session.commit()
+    await session.refresh(subject)
+    
+    exam_config = ExamConfig(subject_id=subject.id, fraction=0)
+    session.add(exam_config)
+    await session.commit()
+    await session.refresh(exam_config)
+    
+    wr = WaitingRoom(exam_config_id=exam_config.id, state=WaitingRoomState.PREPARATION)
+    session.add(wr)
+    await session.commit()
+    await session.refresh(wr)
+    
+    app.dependency_overrides[get_current_user_info] = lambda: prof_with_invalid_groups
+    
+    response = await client.get("/api/waiting-rooms/professor/my-waiting-rooms")
+    
+    assert response.status_code == 200
+    data = response.json()
+    
+    # Should still work, just with valid groups
+    assert "waiting_rooms" in data
+    waiting_rooms = data["waiting_rooms"]
+    
+    # Should have only the valid waiting room that exists
+    assert str(subject.id) in waiting_rooms
+    assert str(wr.id) in waiting_rooms[str(subject.id)]
+
+
+@pytest.mark.asyncio
+async def test_get_professor_waiting_rooms_non_existent_waiting_room(client, session):
+    """Test that non-existent waiting room IDs in groups are handled gracefully."""
+    # Professor has group w999/regent but that waiting room doesn't exist in DB
+    prof_no_wr = User(
+        user_id="prof-no-wr",
+        username="prof_no_wr",
+        email="nowr@example.com",
+        realm_roles=["professor"],
+        groups=["w999/regent"]  # References non-existent waiting room
+    )
+    
+    app.dependency_overrides[get_current_user_info] = lambda: prof_no_wr
+    
+    response = await client.get("/api/waiting-rooms/professor/my-waiting-rooms")
+    
+    assert response.status_code == 200
+    data = response.json()
+    
+    # Should return empty since the waiting room doesn't exist
+    assert data["waiting_rooms"] == {}
+
+
+@pytest.mark.asyncio
+async def test_get_professor_waiting_rooms_multiple_subjects(client, professor_user, setup_waiting_rooms, session):
+    """Test professor with waiting rooms across multiple subjects."""
+    app.dependency_overrides[get_current_user_info] = lambda: professor_user
+    
+    response = await client.get("/api/waiting-rooms/professor/my-waiting-rooms")
+    
+    assert response.status_code == 200
+    data = response.json()
+    
+    waiting_rooms = data["waiting_rooms"]
+    
+    # Verify structure: should have 2 subjects
+    assert len(waiting_rooms) == 2
+    
+    # Verify each subject has correct waiting rooms
+    subject1_rooms = waiting_rooms[str(setup_waiting_rooms["subject1_id"])]
+    assert len(subject1_rooms) == 2  # wr1 and wr2
+    
+    subject2_rooms = waiting_rooms[str(setup_waiting_rooms["subject2_id"])]
+    assert len(subject2_rooms) == 1  # wr3 only
+
+
+@pytest.mark.asyncio
+async def test_get_professor_waiting_rooms_all_states(client, professor_user, setup_waiting_rooms, session):
+    """Test that all waiting room states are correctly returned."""
+    app.dependency_overrides[get_current_user_info] = lambda: professor_user
+    
+    response = await client.get("/api/waiting-rooms/professor/my-waiting-rooms")
+    
+    assert response.status_code == 200
+    data = response.json()
+    
+    waiting_rooms = data["waiting_rooms"]
+    
+    # Collect all states
+    states_found = set()
+    roles_found = set()
+    
+    for subject_id, rooms in waiting_rooms.items():
+        for wr_id, wr_data in rooms.items():
+            states_found.add(wr_data["state"])
+            roles_found.add(wr_data["role"])
+    
+    # Should have all three states
+    assert "preparation" in states_found
+    assert "running" in states_found
+    assert "closed" in states_found
+    
+    # Should have both roles
+    assert "regent" in roles_found
+    assert "vigilant" in roles_found

--- a/api/tests/unit/test_professor_waiting_rooms.py
+++ b/api/tests/unit/test_professor_waiting_rooms.py
@@ -95,7 +95,7 @@ async def setup_waiting_rooms(session):
 
 @pytest.mark.asyncio
 async def test_get_professor_waiting_rooms_success(client, professor_user, setup_waiting_rooms, session):
-    """Test professor can retrieve their waiting rooms grouped by subject."""
+    """Test professor can retrieve their waiting rooms as a flat list."""
     app.dependency_overrides[get_current_user_info] = lambda: professor_user
     
     response = await client.get("/api/waiting-rooms/professor/my-waiting-rooms")
@@ -106,38 +106,41 @@ async def test_get_professor_waiting_rooms_success(client, professor_user, setup
     assert "waiting_rooms" in data
     waiting_rooms = data["waiting_rooms"]
     
-    # Should have entries for both subjects
-    assert str(setup_waiting_rooms["subject1_id"]) in waiting_rooms
-    assert str(setup_waiting_rooms["subject2_id"]) in waiting_rooms
+    # Should be a list with 3 waiting rooms
+    assert isinstance(waiting_rooms, list)
+    assert len(waiting_rooms) == 3
     
-    # Subject 1 should have 2 waiting rooms (wr1 and wr2)
-    subject1_rooms = waiting_rooms[str(setup_waiting_rooms["subject1_id"])]
-    assert str(setup_waiting_rooms["wr1_id"]) in subject1_rooms
-    assert str(setup_waiting_rooms["wr2_id"]) in subject1_rooms
+    # Create a lookup by waiting_room_id for easier assertions
+    wr_lookup = {wr["waiting_room_id"]: wr for wr in waiting_rooms}
     
     # Check wr1 (regent, preparation)
-    wr1_data = subject1_rooms[str(setup_waiting_rooms["wr1_id"])]
-    assert wr1_data["state"] == "preparation"
-    assert wr1_data["role"] == "regent"
+    wr1 = wr_lookup[setup_waiting_rooms["wr1_id"]]
+    assert wr1["subject_id"] == setup_waiting_rooms["subject1_id"]
+    assert wr1["subject_name"] == "Subject 1"
+    assert wr1["waiting_room_id"] == setup_waiting_rooms["wr1_id"]
+    assert wr1["state"] == "preparation"
+    assert wr1["role"] == "regent"
     
     # Check wr2 (vigilant, running)
-    wr2_data = subject1_rooms[str(setup_waiting_rooms["wr2_id"])]
-    assert wr2_data["state"] == "running"
-    assert wr2_data["role"] == "vigilant"
-    
-    # Subject 2 should have 1 waiting room (wr3)
-    subject2_rooms = waiting_rooms[str(setup_waiting_rooms["subject2_id"])]
-    assert str(setup_waiting_rooms["wr3_id"]) in subject2_rooms
+    wr2 = wr_lookup[setup_waiting_rooms["wr2_id"]]
+    assert wr2["subject_id"] == setup_waiting_rooms["subject1_id"]
+    assert wr2["subject_name"] == "Subject 1"
+    assert wr2["waiting_room_id"] == setup_waiting_rooms["wr2_id"]
+    assert wr2["state"] == "running"
+    assert wr2["role"] == "vigilant"
     
     # Check wr3 (regent, closed)
-    wr3_data = subject2_rooms[str(setup_waiting_rooms["wr3_id"])]
-    assert wr3_data["state"] == "closed"
-    assert wr3_data["role"] == "regent"
+    wr3 = wr_lookup[setup_waiting_rooms["wr3_id"]]
+    assert wr3["subject_id"] == setup_waiting_rooms["subject2_id"]
+    assert wr3["subject_name"] == "Subject 2"
+    assert wr3["waiting_room_id"] == setup_waiting_rooms["wr3_id"]
+    assert wr3["state"] == "closed"
+    assert wr3["role"] == "regent"
 
 
 @pytest.mark.asyncio
 async def test_get_professor_waiting_rooms_empty(client, professor_user_no_waiting_rooms, session):
-    """Test professor with no waiting room groups gets empty response."""
+    """Test professor with no waiting room groups gets empty list."""
     app.dependency_overrides[get_current_user_info] = lambda: professor_user_no_waiting_rooms
     
     response = await client.get("/api/waiting-rooms/professor/my-waiting-rooms")
@@ -146,7 +149,7 @@ async def test_get_professor_waiting_rooms_empty(client, professor_user_no_waiti
     data = response.json()
     
     assert "waiting_rooms" in data
-    assert data["waiting_rooms"] == {}
+    assert data["waiting_rooms"] == []
 
 
 @pytest.mark.asyncio
@@ -197,15 +200,14 @@ async def test_get_professor_waiting_rooms_partial_groups(client, session):
     assert "waiting_rooms" in data
     waiting_rooms = data["waiting_rooms"]
     
-    # Should have only one subject
+    # Should be a list with one item
+    assert isinstance(waiting_rooms, list)
     assert len(waiting_rooms) == 1
-    assert str(subject.id) in waiting_rooms
     
-    # Should have only one waiting room
-    assert len(waiting_rooms[str(subject.id)]) == 1
-    assert str(wr.id) in waiting_rooms[str(subject.id)]
-    
-    wr_data = waiting_rooms[str(subject.id)][str(wr.id)]
+    wr_data = waiting_rooms[0]
+    assert wr_data["subject_id"] == subject.id
+    assert wr_data["subject_name"] == "Test Subject"
+    assert wr_data["waiting_room_id"] == wr.id
     assert wr_data["state"] == "running"
     assert wr_data["role"] == "regent"
 
@@ -254,8 +256,9 @@ async def test_get_professor_waiting_rooms_invalid_group_format(client, session)
     waiting_rooms = data["waiting_rooms"]
     
     # Should have only the valid waiting room that exists
-    assert str(subject.id) in waiting_rooms
-    assert str(wr.id) in waiting_rooms[str(subject.id)]
+    assert isinstance(waiting_rooms, list)
+    assert len(waiting_rooms) == 1
+    assert waiting_rooms[0]["waiting_room_id"] == wr.id
 
 
 @pytest.mark.asyncio
@@ -277,59 +280,48 @@ async def test_get_professor_waiting_rooms_non_existent_waiting_room(client, ses
     assert response.status_code == 200
     data = response.json()
     
-    # Should return empty since the waiting room doesn't exist
-    assert data["waiting_rooms"] == {}
+    # Should return empty list since the waiting room doesn't exist
+    assert data["waiting_rooms"] == []
 
 
 @pytest.mark.asyncio
 async def test_get_professor_waiting_rooms_multiple_subjects(client, professor_user, setup_waiting_rooms, session):
     """Test professor with waiting rooms across multiple subjects."""
     app.dependency_overrides[get_current_user_info] = lambda: professor_user
-    
+
     response = await client.get("/api/waiting-rooms/professor/my-waiting-rooms")
-    
+
     assert response.status_code == 200
     data = response.json()
-    
+
     waiting_rooms = data["waiting_rooms"]
-    
-    # Verify structure: should have 2 subjects
-    assert len(waiting_rooms) == 2
-    
-    # Verify each subject has correct waiting rooms
-    subject1_rooms = waiting_rooms[str(setup_waiting_rooms["subject1_id"])]
-    assert len(subject1_rooms) == 2  # wr1 and wr2
-    
-    subject2_rooms = waiting_rooms[str(setup_waiting_rooms["subject2_id"])]
-    assert len(subject2_rooms) == 1  # wr3 only
+
+    # Should be a list with 3 waiting rooms
+    assert isinstance(waiting_rooms, list)
+    assert len(waiting_rooms) == 3
 
 
 @pytest.mark.asyncio
 async def test_get_professor_waiting_rooms_all_states(client, professor_user, setup_waiting_rooms, session):
     """Test that all waiting room states are correctly returned."""
     app.dependency_overrides[get_current_user_info] = lambda: professor_user
-    
+
     response = await client.get("/api/waiting-rooms/professor/my-waiting-rooms")
-    
+
     assert response.status_code == 200
     data = response.json()
-    
+
     waiting_rooms = data["waiting_rooms"]
-    
-    # Collect all states
-    states_found = set()
-    roles_found = set()
-    
-    for subject_id, rooms in waiting_rooms.items():
-        for wr_id, wr_data in rooms.items():
-            states_found.add(wr_data["state"])
-            roles_found.add(wr_data["role"])
-    
+
+    # Collect all states and roles
+    states_found = set(wr["state"] for wr in waiting_rooms)
+    roles_found = set(wr["role"] for wr in waiting_rooms)
+
     # Should have all three states
     assert "preparation" in states_found
     assert "running" in states_found
     assert "closed" in states_found
-    
+
     # Should have both roles
     assert "regent" in roles_found
     assert "vigilant" in roles_found


### PR DESCRIPTION
# Description

Pretty self explanatory, but added the endpoint to return my own waiting rooms (either the regent or vigilant). Here's a more detailed explanation:


Get all waiting rooms where the professor is either a regent or vigilant.

Returns a flat list of waiting rooms with subject information:
```json
{
    "waiting_rooms": [
        {
            "subject_id": 1,
            "subject_name": "Mathematics",
            "waiting_room_id": 5,
            "state": "preparation" | "running" | "closed",
            "role": "regent" | "vigilant"
        }
    ]
}
```

Only accessible by users with the professor role.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Added unit test to validate implementation and all other tests pass.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
