### PR TITLE
Fix/my waiting rooms endpoint now returns exam name

### DIFF
--- a/api/src/models/exam_config.py
+++ b/api/src/models/exam_config.py
@@ -7,13 +7,14 @@ from src.models.topic_config import TopicConfigDTO
 # ExamConfig model
 class ExamConfig(SQLModel, table=True):
     __tablename__ = "exam_config"
-    
+
     id: Optional[int] = Field(default=None, primary_key=True)
     #creator_keycloak_id: str = Field(max_length=255)
     fraction: int = Field(default=0)
     subject_id: int = Field(foreign_key="subject.id")
     nmec_name_list: Optional[str] # nmec (string): {name: string, email: string}
-    
+    exam_name: Optional[str] = Field(default=None, max_length=255)
+
     topic_configs: List["TopicConfig"] = Relationship(back_populates="exam_config",
                                                      sa_relationship_kwargs={"cascade": "all, delete-orphan"})
     exams: List["Exam"] = Relationship(back_populates="exam_config")
@@ -25,6 +26,7 @@ class ExamConfigCreate(SQLModel):
     fraction: int = 0
     subject_id: int
     nmec_list: Optional[str] #dict{nmec : nome}
+    exam_name: Optional[str] = None
 
 class ExamConfigUpdate(SQLModel):
     """Schema for updating exam configuration"""

--- a/api/src/models/waiting_room.py
+++ b/api/src/models/waiting_room.py
@@ -57,3 +57,4 @@ class ProfessorWaitingRoomItem(BaseModel):
     waiting_room_id: int
     state: str
     role: str
+    exam_name: Optional[str]

--- a/api/src/services/exam.py
+++ b/api/src/services/exam.py
@@ -64,7 +64,7 @@ async def create_configs(
         subject_id=exam_specs["subject_id"],
         fraction=exam_specs["fraction"],
         nmec_name_list=nmec_name_list,
-        exam_name=exam_specs.get("exam_name", None)
+        exam_name=exam_specs.get("exam_name") or exam_specs.get("exam_title", None)
         #creator_keycloak_id=dummy_user_id
     )
     session.add(exam_config)

--- a/api/src/services/exam.py
+++ b/api/src/services/exam.py
@@ -63,7 +63,8 @@ async def create_configs(
     exam_config = ExamConfig(
         subject_id=exam_specs["subject_id"],
         fraction=exam_specs["fraction"],
-        nmec_name_list=nmec_name_list
+        nmec_name_list=nmec_name_list,
+        exam_name=exam_specs.get("exam_name", None)
         #creator_keycloak_id=dummy_user_id
     )
     session.add(exam_config)

--- a/api/src/services/waiting_room.py
+++ b/api/src/services/waiting_room.py
@@ -354,7 +354,8 @@ async def get_professor_waiting_rooms(
             subject_name=subject.name,
             waiting_room_id=wr.id,
             state=wr.state.value,
-            role=role
+            role=role,
+            exam_name=exam_config.exam_name
         ))
     
     return result

--- a/api/tests/unit/test_professor_waiting_rooms.py
+++ b/api/tests/unit/test_professor_waiting_rooms.py
@@ -61,9 +61,9 @@ async def setup_waiting_rooms(session):
     await session.refresh(subject2)
 
     # Create exam configs
-    exam_config1 = ExamConfig(subject_id=subject1.id, fraction=0)
-    exam_config2 = ExamConfig(subject_id=subject1.id, fraction=1)
-    exam_config3 = ExamConfig(subject_id=subject2.id, fraction=0)
+    exam_config1 = ExamConfig(subject_id=subject1.id, fraction=0, exam_name="Exam Config 1")
+    exam_config2 = ExamConfig(subject_id=subject1.id, fraction=1, exam_name="Exam Config 2")
+    exam_config3 = ExamConfig(subject_id=subject2.id, fraction=0, exam_name="Exam Config 3")
     session.add(exam_config1)
     session.add(exam_config2)
     session.add(exam_config3)
@@ -117,7 +117,8 @@ async def test_get_professor_waiting_rooms_success(client, professor_user, setup
     assert wr1["waiting_room_id"] == setup_waiting_rooms["wr1_id"]
     assert wr1["state"] == "preparation"
     assert wr1["role"] == "regent"
-    
+    assert wr1["exam_name"] == "Exam Config 1"
+
     # Check wr2 (vigilant, running)
     wr2 = wr_lookup[setup_waiting_rooms["wr2_id"]]
     assert wr2["subject_id"] == setup_waiting_rooms["subject1_id"]
@@ -125,7 +126,8 @@ async def test_get_professor_waiting_rooms_success(client, professor_user, setup
     assert wr2["waiting_room_id"] == setup_waiting_rooms["wr2_id"]
     assert wr2["state"] == "running"
     assert wr2["role"] == "vigilant"
-    
+    assert wr2["exam_name"] == "Exam Config 2"
+
     # Check wr3 (regent, closed)
     wr3 = wr_lookup[setup_waiting_rooms["wr3_id"]]
     assert wr3["subject_id"] == setup_waiting_rooms["subject2_id"]
@@ -133,6 +135,7 @@ async def test_get_professor_waiting_rooms_success(client, professor_user, setup
     assert wr3["waiting_room_id"] == setup_waiting_rooms["wr3_id"]
     assert wr3["state"] == "closed"
     assert wr3["role"] == "regent"
+    assert wr3["exam_name"] == "Exam Config 3"
 
 
 @pytest.mark.asyncio
@@ -177,33 +180,34 @@ async def test_get_professor_waiting_rooms_partial_groups(client, session):
     await session.commit()
     await session.refresh(subject)
     
-    exam_config = ExamConfig(subject_id=subject.id, fraction=0)
+    exam_config = ExamConfig(subject_id=subject.id, fraction=0, exam_name="Test Exam")
     session.add(exam_config)
     await session.commit()
     await session.refresh(exam_config)
-    
+
     wr = WaitingRoom(exam_config_id=exam_config.id, state=WaitingRoomState.RUNNING)
     session.add(wr)
     await session.commit()
     await session.refresh(wr)
-    
+
     app.dependency_overrides[get_current_user_info] = lambda: partial_prof
-    
+
     response = await client.get("/api/waiting-rooms/professor/my-waiting-rooms")
-    
+
     assert response.status_code == 200
     waiting_rooms = response.json()
-    
+
     # Should be a list with one item
     assert isinstance(waiting_rooms, list)
     assert len(waiting_rooms) == 1
-    
+
     wr_data = waiting_rooms[0]
     assert wr_data["subject_id"] == subject.id
     assert wr_data["subject_name"] == "Test Subject"
     assert wr_data["waiting_room_id"] == wr.id
     assert wr_data["state"] == "running"
     assert wr_data["role"] == "regent"
+    assert wr_data["exam_name"] == "Test Exam"
 
 
 @pytest.mark.asyncio
@@ -228,27 +232,28 @@ async def test_get_professor_waiting_rooms_invalid_group_format(client, session)
     await session.commit()
     await session.refresh(subject)
     
-    exam_config = ExamConfig(subject_id=subject.id, fraction=0)
+    exam_config = ExamConfig(subject_id=subject.id, fraction=0, exam_name="Test Exam")
     session.add(exam_config)
     await session.commit()
     await session.refresh(exam_config)
-    
+
     wr = WaitingRoom(exam_config_id=exam_config.id, state=WaitingRoomState.PREPARATION)
     session.add(wr)
     await session.commit()
     await session.refresh(wr)
-    
+
     app.dependency_overrides[get_current_user_info] = lambda: prof_with_invalid_groups
-    
+
     response = await client.get("/api/waiting-rooms/professor/my-waiting-rooms")
-    
+
     assert response.status_code == 200
     waiting_rooms = response.json()
-    
+
     # Should have only the valid waiting room that exists
     assert isinstance(waiting_rooms, list)
     assert len(waiting_rooms) == 1
     assert waiting_rooms[0]["waiting_room_id"] == wr.id
+    assert waiting_rooms[0]["exam_name"] == "Test Exam"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# Description

Added exam_name parameter to exam_config for persistent storage of it (it stores it based on the exam_title parameter passed by the frontend).
Also returned the exam_name in the my-waiting-rooms endpoint.

## Type of change

- [x] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

Updated unit tests to verify. Also booted up the entire thing to verify the fix manually. All other tests are also passing.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
