### PR TITLE
fixed grid image, now shows the correctly cropped image and the omr classification overlay

### DIFF
--- a/api/src/services/omr.py
+++ b/api/src/services/omr.py
@@ -217,18 +217,16 @@ async def evaluate_exam(
     total_exam_score = max(0.0, total_exam_score)
     print(f"\nFINAL EXAM SCORE: {total_exam_score:.2f} / 20.00")
 
+    # Save the colored correction image and use it as capture_path
+    name_parts = image_path.rsplit(".", 1)
+    correction_path = f"{name_parts[0]}_omr_correction.{name_parts[1]}"
+    cv2.imwrite(correction_path, grid_paper)
+
     # Persist results to the database
     exam.grade = total_exam_score
     exam.results = json.dumps(answered_dict)
-    exam.capture_path = image_path
+    exam.capture_path = correction_path
 
     session.add(exam)
     await session.commit()
     await session.refresh(exam)
-
-    # I am assuming this save is for debug. 
-    # I would urge my colleagues to leave debugs in writting for future reference thought. Something like:
-    # Debug => saving image to check it out.
-    new_name = image_path.rsplit(".", 1)
-    new_name = f"{new_name[0]}_omr_correction.{new_name[1]}"
-    cv2.imwrite(new_name, grid_paper)


### PR DESCRIPTION
# Description
This pull request updates the exam evaluation process to ensure that the corrected (colored) OMR image is saved and referenced in the database, rather than the original image. This improves traceability and clarity for future reference.

Image saving and database persistence:

* The corrected OMR image is now saved as a new file (with `_omr_correction` appended to the filename), and this corrected image path is stored in the `exam.capture_path` field instead of the original image path.
* Old debug code for saving the corrected image has been removed, consolidating the image-saving logic and reducing redundancy.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update