### PR TITLE
Fix/new omr border treshold

### DIFF
--- a/api/src/latex_templates/Rules.tex
+++ b/api/src/latex_templates/Rules.tex
@@ -1,10 +1,13 @@
 \newcommand\Rules{O exame tem $#NUM_QUESTIONS$ perguntas de escolha múltipla. 
 
-As perguntas de escolha múltipla tem apenas uma resposta correta, devem ser respondidas na grelha presente nesta página do enunciado com um \textbf{X}. Para anular uma resposta, o aluno deve preencher a célula. As respostas anuladas não descontam, mas as erradas \textbf{descontam} (cotação da pergunta $\times$ #FRACTION).
+As perguntas de escolha múltipla tem apenas uma resposta correta, devem ser respondidas na grelha presente nesta página do enunciado com um \textbf{X}. Para anular uma resposta, o aluno deve preencher \textbf{completamente} a célula. As respostas anuladas não descontam, mas as erradas \textbf{descontam} (cotação da pergunta $\times$ #FRACTION).
+
+Se uma célula de resposta ficar inutilizável (por exemplo, se a preencheu completamente para a anular, mas mais tarde decidir que é a sua resposta final), indique a opção correta no espaço em redor da grelha de respostas. No entanto, isto deve ser feito \textbf{estritamente} dentro da linha picotada.
 
 A duração total do exame é de \textbf{1h30}.\\
 
 \textit{The exam has $#NUM_QUESTIONS$ multiple-choice questions.\\
-The multiple-choice questions have only one correct answer and should be answered in the grid provided on this page of the exam with an \textbf{X}. To cancel an answer, the student should fill in the cell. Canceled answers do not result in deductions, but incorrect answers \textbf{deduct} (question score $\times$ #FRACTION).\\
+The multiple-choice questions have only one correct answer and should be answered in the grid provided on this page of the exam with an \textbf{X}. To cancel an answer, the student should  \textbf{completely} fill in the cell. Canceled answers do not result in deductions, but incorrect answers \textbf{deduct} (question score $\times$ #FRACTION).\\
+If an answer cell becomes unusable (for example, if you completely filled it in to cancel it but later decide it is your final answer), please write the correct option in the space around the answer grid. However, this must be done \textbf{strictly} within the dotted line.\\
 The total duration of the exam is \textbf{1h30}.}\\
 }

--- a/api/src/services/exam.py
+++ b/api/src/services/exam.py
@@ -334,7 +334,6 @@ def _update_rules(workdir: str, num_questions: int, fraction: float):
     with open(rules_path, "w") as f:
         f.write(content)
 
-
 def _write_blank_answers(workdir: str, num_questions: int):
     """Write blank T-answers.tex for student exam."""
     cols = num_questions
@@ -347,19 +346,20 @@ def _write_blank_answers(workdir: str, num_questions: int):
     
     content = f"""\\renewcommand{{\\arraystretch}}{{1.5}}
 \\begin{{center}}
-\\begin{{minipage}}{{0.15\\textwidth}}
 \\qrcode[height=0.75in]{{\\qrcodecontent}}
-\\end{{minipage}}%
-\\begin{{minipage}}{{0.80\\textwidth}}
-\\scriptsize
+\\end{{center}}
+\\vspace{{0.3cm}}
 \\begin{{center}}
+\\begin{{tikzpicture}}
+\\node[draw, dotted, thick, inner sep=1.5cm] {{
+\\scriptsize
 \\begin{{tabular}}{{|l|{'l|' * cols}}}
 \\hline
  &{header}\\\\ \\hline
 {chr(10).join(rows)}
-\end{{tabular}}
-\end{{center}}
-\\end{{minipage}}
+\\end{{tabular}}
+}};
+\\end{{tikzpicture}}
 \\end{{center}}
 \\vspace{{0.25cm}}
 """
@@ -379,19 +379,20 @@ def _write_answer_key(workdir: str, answers: Dict[int, str], num_questions: int)
     
     content = f"""\\renewcommand{{\\arraystretch}}{{1.5}}
 \\begin{{center}}
-\\begin{{minipage}}{{0.15\\textwidth}}
 \\qrcode[height=0.75in]{{\\qrcodecontent}}
-\\end{{minipage}}%
-\\begin{{minipage}}{{0.80\\textwidth}}
-\\scriptsize
+\\end{{center}}
+\\vspace{{0.3cm}}
 \\begin{{center}}
+\\begin{{tikzpicture}}
+\\node[draw, dotted, thick, inner sep=1.5cm] {{
+\\scriptsize
 \\begin{{tabular}}{{|l|{'l|' * cols}}}
 \\hline
  &{header}\\\\ \\hline
 {chr(10).join(rows)}
-\end{{tabular}}
-\end{{center}}
-\\end{{minipage}}
+\\end{{tabular}}
+}};
+\\end{{tikzpicture}}
 \\end{{center}}
 \\vspace{{0.25cm}}
 """

--- a/api/src/services/omr.py
+++ b/api/src/services/omr.py
@@ -217,18 +217,16 @@ async def evaluate_exam(
     total_exam_score = max(0.0, total_exam_score)
     print(f"\nFINAL EXAM SCORE: {total_exam_score:.2f} / 20.00")
 
+    # Save the colored correction image and use it as capture_path
+    name_parts = image_path.rsplit(".", 1)
+    correction_path = f"{name_parts[0]}_omr_correction.{name_parts[1]}"
+    cv2.imwrite(correction_path, grid_paper)
+
     # Persist results to the database
     exam.grade = total_exam_score
     exam.results = json.dumps(answered_dict)
-    exam.capture_path = image_path
+    exam.capture_path = correction_path
 
     session.add(exam)
     await session.commit()
     await session.refresh(exam)
-
-    # I am assuming this save is for debug. 
-    # I would urge my colleagues to leave debugs in writting for future reference thought. Something like:
-    # Debug => saving image to check it out.
-    new_name = image_path.rsplit(".", 1)
-    new_name = f"{new_name[0]}_omr_correction.{new_name[1]}"
-    cv2.imwrite(new_name, grid_paper)

--- a/api/src/services/omr.py
+++ b/api/src/services/omr.py
@@ -44,8 +44,8 @@ async def evaluate_exam(
     qr_w = qr_x_max - qr_x_min
     qr_h = qr_y_max - qr_y_min
     
-    # Calculate the horizontal center line of the QR code
-    qr_cy = qr_y_min + (qr_h / 2.0)
+    # Calculate the horizontal center of the QR code
+    qr_cx = qr_x_min + (qr_w / 2.0)
 
     # 2. Preprocess the image for Grid Extraction
     gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
@@ -72,25 +72,25 @@ async def evaluate_exam(
             aspect_ratio = w / float(h) if h > 0 else 0
             
             # Center of the current contour
-            c_cy = y + (h / 2.0)
-            y_diff = abs(qr_cy - c_cy)
+            c_cx = x + (w / 2.0)
+            x_diff = abs(qr_cx - c_cx)
             
             # SPATIAL LOGIC: 
-            # 1. To the right: Grid's X starts after the QR code (allowing slight margin of error)
-            # 2. Aligned: Grid's center Y is roughly aligned with the QR code's center Y
-            # 3. Size: Grid is strictly larger than the QR code (replaces brittle image_area % check)
+            # 1. Below: Grid's Y starts after the QR code (allowing slight margin of error)
+            # 2. Aligned: Grid's center X is roughly aligned with the QR code's center X
+            # 3. Size: Grid is strictly larger than the QR code
             # 4. Shape: Grid is horizontally wide
             
-            is_to_the_right = x > (qr_x_max - (qr_w * 0.5)) 
-            is_aligned_horizontally = y_diff < (qr_h * 2.0)
+            is_below = y > (qr_y_max - (qr_h * 0.5))
+            is_aligned_horizontally = x_diff < (qr_w * 2.0)
             is_larger_than_qr = area > (qr_w * qr_h * 2.0)
             
-            if is_to_the_right and is_aligned_horizontally and is_larger_than_qr and aspect_ratio > 3.0:
+            if is_below and is_aligned_horizontally and is_larger_than_qr and aspect_ratio > 3.0:
                 targetCnt = approx
                 break
 
     if targetCnt is None:
-        raise Exception("Found the QR Code, but could not locate the adjacent answer grid.")
+        raise Exception("Found the QR Code, but could not locate the answer grid below it.")
 
     # 4. Apply the perspective transform (Bird's-eye view) directly on the grid
     paper = four_point_transform(image, targetCnt.reshape(4, 2))

--- a/api/src/services/omr.py
+++ b/api/src/services/omr.py
@@ -2,9 +2,9 @@ from src.models.exam import Exam
 from src.services.exam import get_exam_config_by_id
 from sqlmodel.ext.asyncio.session import AsyncSession
 
-from imutils.perspective import four_point_transform
-from imutils import contours
+from imutils.perspective import order_points
 import imutils
+import numpy as np
 import cv2
 import json
 
@@ -28,7 +28,7 @@ async def evaluate_exam(
     num_questions = len(answer_key)
     image = cv2.imread(image_path)
 
-    # Detect QR Code to use as an anchor
+    # 1. Detect QR Code to use as an anchor
     qr_detector = cv2.QRCodeDetector()
     retval, bbox = qr_detector.detect(image)
 
@@ -43,8 +43,6 @@ async def evaluate_exam(
     qr_y_max = int(max(qr_pts[:, 1]))
     qr_w = qr_x_max - qr_x_min
     qr_h = qr_y_max - qr_y_min
-    
-    # Calculate the horizontal center of the QR code
     qr_cx = qr_x_min + (qr_w / 2.0)
 
     # 2. Preprocess the image for Grid Extraction
@@ -54,32 +52,28 @@ async def evaluate_exam(
 
     cnts = cv2.findContours(edged.copy(), cv2.RETR_TREE, cv2.CHAIN_APPROX_SIMPLE)
     cnts = imutils.grab_contours(cnts)
-    
-    # Sort contours by area (largest first)
     cnts = sorted(cnts, key=cv2.contourArea, reverse=True)
 
-    # 3. Dynamically find the target box using relative spatial constraints
+    # 3. Dynamically find the target box (The solid grid)
     targetCnt = None
-
     for c in cnts:
-        peri = cv2.arcLength(c, True)
-        approx = cv2.approxPolyDP(c, 0.02 * peri, True)
+        # Wrap the contour in a Convex Hull first ---
+        hull = cv2.convexHull(c)
         
-        # We are looking for a quadrilateral (4 points)
+        # Calculate perimeter and approximate the polygon based on the HULL
+        peri = cv2.arcLength(hull, True)
+        
+        # You can also slightly increase the smoothing threshold from 0.02 to 0.03 for extra safety
+        approx = cv2.approxPolyDP(hull, 0.03 * peri, True) 
+        # --------------------------------------------------------
+        
         if len(approx) == 4:
-            area = cv2.contourArea(c)
-            x, y, w, h = cv2.boundingRect(c)
+            area = cv2.contourArea(c) # keep using original area for size checks
+            x, y, w, h = cv2.boundingRect(approx)
             aspect_ratio = w / float(h) if h > 0 else 0
             
-            # Center of the current contour
             c_cx = x + (w / 2.0)
             x_diff = abs(qr_cx - c_cx)
-            
-            # SPATIAL LOGIC: 
-            # 1. Below: Grid's Y starts after the QR code (allowing slight margin of error)
-            # 2. Aligned: Grid's center X is roughly aligned with the QR code's center X
-            # 3. Size: Grid is strictly larger than the QR code
-            # 4. Shape: Grid is horizontally wide
             
             is_below = y > (qr_y_max - (qr_h * 0.5))
             is_aligned_horizontally = x_diff < (qr_w * 2.0)
@@ -92,17 +86,49 @@ async def evaluate_exam(
     if targetCnt is None:
         raise Exception("Found the QR Code, but could not locate the answer grid below it.")
 
-    # 4. Apply the perspective transform (Bird's-eye view) directly on the grid
-    paper = four_point_transform(image, targetCnt.reshape(4, 2))
-    warped = four_point_transform(gray, targetCnt.reshape(4, 2))
+    # Capture dotted line area
+    # Order the points of the solid grid
+    rect = order_points(targetCnt.reshape(4, 2))
+    (tl, tr, br, bl) = rect
 
-    # 3. Apply Thresholding
-    thresh = cv2.threshold(warped, 0, 255, cv2.THRESH_BINARY_INV | cv2.THRESH_OTSU)[1]
+    # Calculate width and height of the inner grid
+    widthA = np.sqrt(((br[0] - bl[0]) ** 2) + ((br[1] - bl[1]) ** 2))
+    widthB = np.sqrt(((tr[0] - tl[0]) ** 2) + ((tr[1] - tl[1]) ** 2))
+    maxWidth = max(int(widthA), int(widthB))
 
-    grid_paper = paper.copy()
-    grid_thresh = thresh.copy()
+    heightA = np.sqrt(((tr[0] - br[0]) ** 2) + ((tr[1] - br[1]) ** 2))
+    heightB = np.sqrt(((tl[0] - bl[0]) ** 2) + ((tl[1] - bl[1]) ** 2))
+    maxHeight = max(int(heightA), int(heightB))
 
-    # divide the grid into 4 rows x 13 columns (Now 5 rows x 18 cols for the new format)
+    # Calculate padding based on the LaTeX "inner sep=1.5cm"
+    # 1.5cm is approx 60% of the grid height, and 15% of the grid width
+    pad_x = int(maxWidth * 0.15)
+    pad_y = int(maxHeight * 0.60)
+
+    # Destination points: The grid corners inside a LARGER padded canvas
+    dst = np.array([
+        [pad_x, pad_y],
+        [maxWidth - 1 + pad_x, pad_y],
+        [maxWidth - 1 + pad_x, maxHeight - 1 + pad_y],
+        [pad_x, maxHeight - 1 + pad_y]
+    ], dtype="float32")
+
+    # The size of our final capture_path image
+    warped_w = maxWidth + (2 * pad_x)
+    warped_h = maxHeight + (2 * pad_y)
+
+    # Execute the padded transform
+    M = cv2.getPerspectiveTransform(rect, dst)
+    outer_paper = cv2.warpPerspective(image, M, (warped_w, warped_h))
+    outer_gray = cv2.warpPerspective(gray, M, (warped_w, warped_h))
+
+    # Apply Thresholding to the entire padded area
+    outer_thresh = cv2.threshold(outer_gray, 0, 255, cv2.THRESH_BINARY_INV | cv2.THRESH_OTSU)[1]
+
+    # Extract strictly the inner grid for OMR pixel counting
+    grid_thresh = outer_thresh[pad_y : pad_y + maxHeight, pad_x : pad_x + maxWidth]
+
+    # divide the grid into 5 rows x 21 columns
     h, w = grid_thresh.shape
     cell_h = h / 5.0  
     cell_w = w / (num_questions + 1.0)
@@ -112,7 +138,6 @@ async def evaluate_exam(
     margin_w = int(cell_w * 0.15)
 
     answers_details = dict()
-
     answered_dict = dict()
 
     # iterate through each column (question) - skip first column
@@ -120,8 +145,6 @@ async def evaluate_exam(
         cell_coords = []
         cell_totals = []
         answers_details[q] = dict()
-        
-        # Initialize the sub-dictionary for the current question ---
         answered_dict[str(q)] = dict()
         
         erased = 0
@@ -135,7 +158,7 @@ async def evaluate_exam(
             x1 = int((q + 1) * cell_w)
             x2 = int((q + 2) * cell_w)
             
-            # CROP WITH MARGINS
+            # CROP WITH MARGINS inside the grid_thresh
             cell = grid_thresh[y1 + margin_h : y2 - margin_h, x1 + margin_w : x2 - margin_w]
             total = cv2.countNonZero(cell)
             
@@ -159,20 +182,19 @@ async def evaluate_exam(
             if fill_ratio <= 0.85:  # not fully filled (not erased)
                 valid_selected.append(opt)
                 
-        # Populate answered_dict based on valid_selected ---
+        # Populate answered_dict based on valid_selected
         for opt in range(NUM_OPTIONS):
-            option_letter = chr(65 + opt) # Converts 0->A, 1->B, 2->C, 3->D
-            # True if the option is in valid_selected, False otherwise (including erased)
+            option_letter = chr(65 + opt) 
             answered_dict[str(q)][option_letter] = (opt in valid_selected)
         
-        # draw all cells in black (using original outer coordinates for visual precision)
+        k = answer_key[q]
+
+        # Draw all cells in black on the OUTER PAPER (shifting by pad_x and pad_y)
         for opt in range(NUM_OPTIONS):
             x1, y1, x2, y2 = cell_coords[opt]
-            cv2.rectangle(grid_paper, (x1, y1), (x2, y2), (0, 0, 0), 2)
+            cv2.rectangle(outer_paper, (x1 + pad_x, y1 + pad_y), (x2 + pad_x, y2 + pad_y), (0, 0, 0), 2)
         
-        k = answer_key[q]
-        
-        # draw all selected cells
+        # Draw selected colored cells on the OUTER PAPER
         for opt in selected:
             x1, y1, x2, y2 = cell_coords[opt]
             eval_area = (x2 - x1 - (2 * margin_w)) * (y2 - y1 - (2 * margin_h))
@@ -188,8 +210,12 @@ async def evaluate_exam(
                 color = (0, 0, 255)
                 incorrect += 1
             
-            # Draw the rectangle slightly inset so it doesn't overlap the black grid lines
-            cv2.rectangle(grid_paper, (x1+2, y1+2), (x2-2, y2-2), color, 3)
+            # Apply padding offset to position the color box directly over the inner grid
+            p_x1, p_y1 = x1 + pad_x, y1 + pad_y
+            p_x2, p_y2 = x2 + pad_x, y2 + pad_y
+            
+            # Draw inset rectangle
+            cv2.rectangle(outer_paper, (p_x1 + 2, p_y1 + 2), (p_x2 - 2, p_y2 - 2), color, 3)
 
         answers_details[q]["erased"] = erased
         answers_details[q]["correct"] = correct
@@ -201,26 +227,18 @@ async def evaluate_exam(
 
     for q, info in answers_details.items():
         q_weight = relative_weights[q]
-        
-        # Calculate base value of the question
         q_value = (q_weight / sum_weights) * 20.0
-        
-        # Calculate the penalty for an incorrect option
         penalty_per_wrong = q_value * (fraction / 100.0)
-        
-        # Calculate final score for this specific question
         q_score = (info["correct"] * q_value) - (info["incorrect"] * penalty_per_wrong)
-        
         total_exam_score += q_score
 
-    # Floor the total score at 0 to prevent negative exam results (optional)
     total_exam_score = max(0.0, total_exam_score)
     print(f"\nFINAL EXAM SCORE: {total_exam_score:.2f} / 20.00")
 
-    # Save the colored correction image and use it as capture_path
+    # Save the padded image as the final capture path
     name_parts = image_path.rsplit(".", 1)
     correction_path = f"{name_parts[0]}_omr_correction.{name_parts[1]}"
-    cv2.imwrite(correction_path, grid_paper)
+    cv2.imwrite(correction_path, outer_paper)
 
     # Persist results to the database
     exam.grade = total_exam_score


### PR DESCRIPTION
# Description
This pull request makes several important changes to the exam LaTeX template and the OMR (Optical Mark Recognition) exam evaluation pipeline. The main improvements clarify exam instructions for students, update the answer grid rendering to include a dotted area for corrections, and enhance the OMR logic to accurately capture and process this new answer region. The OMR image processing is refactored for robustness and now saves annotated correction images.

**Exam Template and Grid Rendering Updates:**

* The `Rules.tex` template now clarifies that to cancel an answer, the cell must be filled in completely, and provides instructions for indicating a final answer if a cell becomes unusable, specifying that this must be done strictly within the dotted line area.
* The blank answer grid and answer key in the LaTeX templates are now rendered inside a dotted rectangle using TikZ, matching the new instructions and providing a clear area for additional markings. [[1]](diffhunk://#diff-6ed9c7f4538a55c89a89ddc624a762812306ed57f8baaaae3c725a825cf836a4L350-R362) [[2]](diffhunk://#diff-6ed9c7f4538a55c89a89ddc624a762812306ed57f8baaaae3c725a825cf836a4L382-R395)

**OMR Image Processing and Evaluation Enhancements:**

* The OMR pipeline (`evaluate_exam`) is refactored to:
  - Use a convex hull and more robust contour approximation to find the answer grid.
  - Dynamically locate the grid below the QR code using improved spatial logic.
  - Extract a padded region around the grid (matching the LaTeX "inner sep") to include the dotted correction area in the processed image. [[1]](diffhunk://#diff-4b2652153a6c48f8007ab3b937d9a0732fe0a37d64ecdec0975c7982768a07a1L5-R7) [[2]](diffhunk://#diff-4b2652153a6c48f8007ab3b937d9a0732fe0a37d64ecdec0975c7982768a07a1L46-R46) [[3]](diffhunk://#diff-4b2652153a6c48f8007ab3b937d9a0732fe0a37d64ecdec0975c7982768a07a1L57-R131)
* All grid cell overlays (black and colored rectangles) are now drawn on this padded "outer_paper" image, ensuring visual alignment with the new template. The final annotated image is saved and its path is stored in the exam record. [[1]](diffhunk://#diff-4b2652153a6c48f8007ab3b937d9a0732fe0a37d64ecdec0975c7982768a07a1L162-R197) [[2]](diffhunk://#diff-4b2652153a6c48f8007ab3b937d9a0732fe0a37d64ecdec0975c7982768a07a1L191-R218) [[3]](diffhunk://#diff-4b2652153a6c48f8007ab3b937d9a0732fe0a37d64ecdec0975c7982768a07a1L204-L234)

These changes together ensure the exam workflow is more robust, user-friendly, and visually consistent between the printed template and the automated grading system.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Live test using a mobile phone to scan the filled exams as well as forcing curls with synthetic images.
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
