### PR TITLE
Added .dockerignore to prevent the deployment from copying local file…

### DIFF
--- a/api/.dockerignore
+++ b/api/.dockerignore
@@ -1,0 +1,5 @@
+.venv/
+__pycache__/
+*.pyc
+.git/
+.env

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -16,4 +16,4 @@ RUN uv sync --frozen --no-cache
 
 COPY . .
 
-CMD ["/app/.venv/bin/fastapi", "run", "src/main.py", "--port", "80", "--host", "0.0.0.0", "--proxy-headers"]
+CMD ["uv", "run", "fastapi", "run", "src/main.py", "--port", "80", "--host", "0.0.0.0", "--proxy-headers"]

--- a/deployment/docker-compose.api.yml
+++ b/deployment/docker-compose.api.yml
@@ -5,7 +5,7 @@ services:
       dockerfile: Dockerfile
     env_file:
       - .env
-    command: ["/app/.venv/bin/alembic", "upgrade", "head"]
+    command: ["uv", "run", "alembic", "upgrade", "head"]
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
…s and changed docker.compose.api.yml and Dockerfile to do 'uv', 'run' instead of '/app/.venv/bin/alembic'

# Description
This pull request updates the Docker and deployment configuration for the `api` service, primarily to standardize command execution using the `uv` tool and to improve Docker build hygiene.

Container command standardization:

* Updated the `CMD` in `api/Dockerfile` to use `uv` for running the FastAPI server, replacing the direct path to the virtual environment binary.
* Changed the `command` in `deployment/docker-compose.api.yml` to use `uv` for running Alembic migrations, ensuring consistency in how commands are executed within containers.

Docker build improvements:

* Added a `.dockerignore` file to exclude virtual environment directories, Python cache files, the `.env` file, and the `.git` directory from the build context, reducing image size and improving build performance.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
```
docker compose -f docker-compose.dev.yml build --no-cache
docker compose -f docker-compose.dev.yml up -d
```